### PR TITLE
perf: 컨셉 쇼케이스 한/영 전환 시 불필요한 API 재요청 제거

### DIFF
--- a/src/app/api/concepts/route.ts
+++ b/src/app/api/concepts/route.ts
@@ -6,7 +6,6 @@ export const dynamic = 'force-dynamic';
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
-    const lang = searchParams.get("lang") || "ko";
     const offset = parseInt(searchParams.get("offset") || "0", 10);
     const limit = parseInt(searchParams.get("limit") || "3", 10);
 
@@ -32,9 +31,11 @@ export async function GET(request: Request) {
 
     const groups = topics.map((topic) => ({
       topicId: topic.id,
-      topicName: lang === "en" && topic.name_en ? topic.name_en : topic.name_ko,
+      topicName_ko: topic.name_ko,
+      topicName_en: topic.name_en,
       concepts: topic.concepts.map((c) => ({
-        name: lang === "en" && c.name_en ? c.name_en : c.name_ko,
+        name_ko: c.name_ko,
+        name_en: c.name_en,
         questionCount: c._count.questions,
       })),
     }));

--- a/src/components/ConceptShowcase.tsx
+++ b/src/components/ConceptShowcase.tsx
@@ -4,13 +4,15 @@ import { useEffect, useState, useRef, useCallback } from 'react';
 import { useLanguage } from '@/contexts/LanguageContext';
 
 interface ConceptItem {
-  name: string;
+  name_ko: string;
+  name_en: string | null;
   questionCount: number;
 }
 
 interface ConceptGroup {
   topicId: string;
-  topicName: string;
+  topicName_ko: string;
+  topicName_en: string | null;
   concepts: ConceptItem[];
 }
 
@@ -46,7 +48,7 @@ export default function ConceptShowcase() {
 
     try {
       const res = await fetch(
-        `/api/concepts?lang=${language}&offset=${currentOffset}&limit=${BATCH_SIZE}`
+        `/api/concepts?offset=${currentOffset}&limit=${BATCH_SIZE}`
       );
       if (!res.ok) throw new Error('Failed to fetch');
       const data: ConceptsResponse = await res.json();
@@ -84,16 +86,12 @@ export default function ConceptShowcase() {
         });
       }
     }
-  }, [language]);
+  }, []);
 
-  // Reset on language change
+  // Initial fetch
   useEffect(() => {
-    offsetRef.current = 0;
-    setGroups([]);
-    setInitialLoading(true);
-    setHasMore(true);
     fetchConcepts(true);
-  }, [language, fetchConcepts]);
+  }, [fetchConcepts]);
 
   // Intersection Observer for infinite scroll
   useEffect(() => {
@@ -166,7 +164,7 @@ export default function ConceptShowcase() {
           >
             <h3 className="text-lg font-semibold text-gray-700 mb-3 flex items-center gap-2">
               <span className="w-2 h-2 rounded-full bg-gradient-to-br from-orange-400 to-amber-500" />
-              {group.topicName}
+              {language === 'en' && group.topicName_en ? group.topicName_en : group.topicName_ko}
               <span className="text-sm font-normal text-gray-400 ml-1">
                 {group.concepts.length}
               </span>
@@ -174,11 +172,11 @@ export default function ConceptShowcase() {
             <div className="flex flex-wrap gap-2">
               {group.concepts.map((concept, i) => (
                 <span
-                  key={concept.name}
+                  key={concept.name_ko}
                   className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-gradient-to-br from-orange-50 to-amber-50 text-gray-700 rounded-full border border-orange-100 hover:border-orange-300 hover:shadow-sm transition-all duration-200 animate-fadeSlideUp"
                   style={{ animationDelay: `${(groupIndex % BATCH_SIZE) * 100 + i * 30}ms` }}
                 >
-                  {concept.name}
+                  {language === 'en' && concept.name_en ? concept.name_en : concept.name_ko}
                   <span className="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-xs font-medium text-orange-600 bg-orange-100 rounded-full">
                     {concept.questionCount}
                   </span>


### PR DESCRIPTION
## Summary
- concepts API가 양쪽 언어(`_ko`/`_en`) 데이터를 모두 반환하도록 변경
- 한/영 전환 시 API 재요청 없이 클라이언트 리렌더링만으로 언어 전환 처리
- `ConceptShowcase` 컴포넌트에서 `language` 의존성 제거하여 불필요한 refetch 방지

## Test plan
- [ ] 홈페이지에서 한/영 토글 시 concepts 섹션이 API 재요청 없이 즉시 전환되는지 확인
- [ ] 네트워크 탭에서 언어 전환 시 `/api/concepts` 요청이 발생하지 않는 것 확인
- [ ] concepts 데이터의 한글/영문 이름이 정상적으로 표시되는지 확인