### PR TITLE
perf: 퀴즈 페이지 한/영 전환 시 불필요한 API 재요청 제거

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -54,7 +54,7 @@ export default function DailyQuizPage() {
       try {
         const res = await fetch('/api/daily-questions');
         if (!res.ok) {
-          throw new Error(t('daily.errorLoad'));
+          throw new Error('daily.errorLoad');
         }
         const data = await res.json();
         setQuestions(data.questions);
@@ -67,7 +67,7 @@ export default function DailyQuizPage() {
       }
     }
     fetchDailyQuestions();
-  }, [t]);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleAnswer = useCallback((isCorrect: boolean) => {
     if (isCorrect) {
@@ -112,7 +112,7 @@ export default function DailyQuizPage() {
         setPendingScoreSubmit(false);
       } else if (res.status === 401) {
         const errorData = await res.json();
-        const errorMsg = errorData.error || t('daily.loginRequired');
+        const errorMsg = errorData.error || 'daily.loginRequired';
         setScoreSubmitError(errorMsg);
         setPendingScoreSubmit(true);
 
@@ -121,15 +121,15 @@ export default function DailyQuizPage() {
           setShowLoginModal(true);
         }
       } else {
-        setScoreSubmitError(t('daily.submitFailed'));
+        setScoreSubmitError('daily.submitFailed');
       }
     } catch (error) {
       console.error('Failed to submit score:', error);
-      setScoreSubmitError(t('daily.networkError'));
+      setScoreSubmitError('daily.networkError');
     } finally {
       setIsSubmittingScore(false);
     }
-  }, [startTime, dailySetId, correctAnswers, questions.length, t]);
+  }, [startTime, dailySetId, correctAnswers, questions.length]);
 
   useEffect(() => {
     if (user && pendingScoreSubmit && isCompleted) {
@@ -172,7 +172,7 @@ export default function DailyQuizPage() {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
-          <p className="text-xl text-red-600 mb-4">{t('common.error')}: {error}</p>
+          <p className="text-xl text-red-600 mb-4">{t('common.error')}: {t(error) !== error ? t(error) : error}</p>
           <div className="flex gap-3 justify-center">
             <button
               onClick={() => {
@@ -297,7 +297,7 @@ export default function DailyQuizPage() {
               {/* 에러 메시지 */}
               {scoreSubmitError && user && !isSubmittingScore && (
                 <div className="p-4 bg-red-50 border border-red-200 rounded-lg">
-                  <p className="text-sm text-red-700">{scoreSubmitError}</p>
+                  <p className="text-sm text-red-700">{t(scoreSubmitError) !== scoreSubmitError ? t(scoreSubmitError) : scoreSubmitError}</p>
                 </div>
               )}
             </div>

--- a/src/app/quiz/[topicId]/page.tsx
+++ b/src/app/quiz/[topicId]/page.tsx
@@ -49,7 +49,7 @@ export default function QuizPage({ params }: QuizPageProps) {
         `/api/questions/${params.topicId}?count=${BATCH_SIZE}${excludeParam}`
       );
       if (!res.ok) {
-        throw new Error(t('quiz.errorLoad'));
+        throw new Error('quiz.errorLoad');
       }
       const data: QuestionData[] = await res.json();
       if (data.length === 0) {
@@ -70,7 +70,7 @@ export default function QuizPage({ params }: QuizPageProps) {
       isFetchingRef.current = false;
       setLoading(false);
     }
-  }, [params.topicId, t]);
+  }, [params.topicId]);
 
   useEffect(() => {
     fetchBatch();
@@ -134,7 +134,7 @@ export default function QuizPage({ params }: QuizPageProps) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
-          <p className="text-xl text-red-600 mb-4">{t('common.error')}: {error}</p>
+          <p className="text-xl text-red-600 mb-4">{t('common.error')}: {t(error) !== error ? t(error) : error}</p>
           <div className="flex gap-3 justify-center">
             <button
               onClick={() => {


### PR DESCRIPTION
## Summary
- Daily/Quiz 페이지에서 `useEffect`/`useCallback` 의존성의 `t` 함수 제거
- 언어 전환 시 `/api/daily-questions`, `/api/questions/[topicId]` 재요청 방지
- 에러 메시지를 번역 키로 저장하고 렌더 시 `t()`로 번역하도록 변경
- API는 이미 양쪽 언어 데이터(`_ko`/`_en`)를 반환하므로 재요청 불필요

## Test plan
- [ ] Daily 퀴즈 페이지에서 한/영 토글 시 네트워크 탭에 `/api/daily-questions` 재요청이 없는 것 확인
- [ ] 주제별 퀴즈 페이지에서 한/영 토글 시 `/api/questions/[topicId]` 재요청이 없는 것 확인
- [ ] 한/영 전환 시 문제, 선택지, 힌트, 해설이 즉시 전환되는지 확인
- [ ] API 에러 발생 시 에러 메시지가 현재 언어로 정상 표시되는지 확인