### PR TITLE
feat: 난이도 필터 UI (#37)

### DIFF
--- a/src/app/api/questions/[topicId]/route.ts
+++ b/src/app/api/questions/[topicId]/route.ts
@@ -53,9 +53,14 @@ export async function GET(
     const difficultyParam = searchParams.get("difficulty");
     if (difficultyParam) {
       const validDifficulties = ["EASY", "MEDIUM", "HARD"];
-      const difficulties = difficultyParam
-        .split(",")
-        .filter((d) => validDifficulties.includes(d));
+      const difficulties = Array.from(
+        new Set(
+          difficultyParam
+            .split(",")
+            .map((d) => d.trim())
+            .filter((d) => validDifficulties.includes(d))
+        )
+      );
       if (difficulties.length > 0 && difficulties.length < 3) {
         (where as any).difficulty = { in: difficulties };
       }

--- a/src/app/api/questions/[topicId]/route.ts
+++ b/src/app/api/questions/[topicId]/route.ts
@@ -49,6 +49,18 @@ export async function GET(
       (where as any).id = { notIn: excludeIds };
     }
 
+    // 난이도 필터
+    const difficultyParam = searchParams.get("difficulty");
+    if (difficultyParam) {
+      const validDifficulties = ["EASY", "MEDIUM", "HARD"];
+      const difficulties = difficultyParam
+        .split(",")
+        .filter((d) => validDifficulties.includes(d));
+      if (difficulties.length > 0 && difficulties.length < 3) {
+        (where as any).difficulty = { in: difficulties };
+      }
+    }
+
     const totalCount = await prisma.question.count({ where });
     if (totalCount === 0) {
       return NextResponse.json([], { status: 200 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ function getHomepageData() {
   return unstable_cache(
     async () => {
       const today = getTodayInKST();
-      const [dbTopics, dailySet] = await Promise.all([
+      const [dbTopics, dailySet, diffGroups] = await Promise.all([
         prisma.topic.findMany({
           include: { _count: { select: { questions: true } } },
         }),
@@ -17,8 +17,12 @@ function getHomepageData() {
           where: { date: today },
           select: { id: true },
         }),
+        prisma.question.groupBy({
+          by: ['topicId', 'difficulty'],
+          _count: { _all: true },
+        }),
       ]);
-      return { dbTopics, dailySet };
+      return { dbTopics, dailySet, diffGroups };
     },
     [`homepage-data-${todayKey}`],
     { revalidate: 3600 }
@@ -30,13 +34,23 @@ export default async function HomePage() {
   let dailySetId: string | null = null;
 
   try {
-    const { dbTopics, dailySet } = await getHomepageData();
+    const { dbTopics, dailySet, diffGroups } = await getHomepageData();
+
+    // Build per-topic difficulty counts
+    const diffMap = new Map<string, { EASY: number; MEDIUM: number; HARD: number }>();
+    for (const g of diffGroups) {
+      if (!diffMap.has(g.topicId)) {
+        diffMap.set(g.topicId, { EASY: 0, MEDIUM: 0, HARD: 0 });
+      }
+      diffMap.get(g.topicId)![g.difficulty] = g._count._all;
+    }
 
     topics = dbTopics.map((topic) => ({
       id: topic.id as Topic['id'],
       name_ko: topic.name_ko,
       name_en: topic.name_en,
       questionCount: topic._count.questions,
+      difficultyCounts: diffMap.get(topic.id) ?? { EASY: 0, MEDIUM: 0, HARD: 0 },
     }));
 
     dailySetId = dailySet?.id ?? null;

--- a/src/app/quiz/[topicId]/page.tsx
+++ b/src/app/quiz/[topicId]/page.tsx
@@ -34,6 +34,11 @@ export default function QuizPage({ params }: QuizPageProps) {
   const seenIdsRef = useRef<Set<string>>(new Set());
   const noMoreQuestionsRef = useRef(false);
 
+  const [selectedDifficulties, setSelectedDifficulties] = useState<Set<string>>(
+    new Set(['EASY', 'MEDIUM', 'HARD'])
+  );
+  const difficultyParam = Array.from(selectedDifficulties).sort().join(',');
+
   // 에러 핸들러용 스냅샷 동기화
   queueSnapshotRef.current = { queueLen: questionQueue.length, idx: currentIndex };
 
@@ -45,8 +50,11 @@ export default function QuizPage({ params }: QuizPageProps) {
       const excludeParam = seenIdsRef.current.size > 0
         ? `&exclude=${Array.from(seenIdsRef.current).join(',')}`
         : '';
+      const diffParam = selectedDifficulties.size < 3
+        ? `&difficulty=${difficultyParam}`
+        : '';
       const res = await fetch(
-        `/api/questions/${params.topicId}?count=${BATCH_SIZE}${excludeParam}`
+        `/api/questions/${params.topicId}?count=${BATCH_SIZE}${excludeParam}${diffParam}`
       );
       if (!res.ok) {
         throw new Error('quiz.errorLoad');
@@ -70,11 +78,20 @@ export default function QuizPage({ params }: QuizPageProps) {
       isFetchingRef.current = false;
       setLoading(false);
     }
-  }, [params.topicId]);
+  }, [params.topicId, difficultyParam]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
+    setQuestionQueue([]);
+    setCurrentIndex(0);
+    seenIdsRef.current = new Set();
+    noMoreQuestionsRef.current = false;
+    setSolvedCount(0);
+    setCorrectCount(0);
+    setError(null);
+    setLoading(true);
+    isFetchingRef.current = false;
     fetchBatch();
-  }, [params.topicId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [params.topicId, difficultyParam]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     const remaining = questionQueue.length - currentIndex;
@@ -98,6 +115,19 @@ export default function QuizPage({ params }: QuizPageProps) {
     }
   };
 
+  const handleDifficultyToggle = (difficulty: string) => {
+    setSelectedDifficulties((prev) => {
+      const next = new Set(prev);
+      if (next.has(difficulty)) {
+        if (next.size === 1) return prev; // 최소 1개 유지
+        next.delete(difficulty);
+      } else {
+        next.add(difficulty);
+      }
+      return next;
+    });
+  };
+
   const handleQuit = async () => {
     if (user && solvedCount > 0) {
       const timeSpent = Math.round((Date.now() - startTimeRef.current) / 1000);
@@ -119,6 +149,44 @@ export default function QuizPage({ params }: QuizPageProps) {
     }
     router.push('/');
   };
+
+  const filterConfig: Record<string, { tKey: string; selected: string; unselected: string }> = {
+    EASY: {
+      tKey: 'quiz.difficultyEasy',
+      selected: 'bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700',
+      unselected: 'bg-gray-100 text-gray-400 border-gray-200 dark:bg-gray-800 dark:text-gray-500 dark:border-gray-700',
+    },
+    MEDIUM: {
+      tKey: 'quiz.difficultyMedium',
+      selected: 'bg-orange-100 text-orange-700 border-orange-300 dark:bg-orange-900/30 dark:text-orange-400 dark:border-orange-700',
+      unselected: 'bg-gray-100 text-gray-400 border-gray-200 dark:bg-gray-800 dark:text-gray-500 dark:border-gray-700',
+    },
+    HARD: {
+      tKey: 'quiz.difficultyHard',
+      selected: 'bg-red-100 text-red-700 border-red-300 dark:bg-red-900/30 dark:text-red-400 dark:border-red-700',
+      unselected: 'bg-gray-100 text-gray-400 border-gray-200 dark:bg-gray-800 dark:text-gray-500 dark:border-gray-700',
+    },
+  };
+
+  const difficultyFilter = (
+    <div className="flex gap-2 mb-6">
+      {(['EASY', 'MEDIUM', 'HARD'] as const).map((diff) => {
+        const cfg = filterConfig[diff];
+        const isSelected = selectedDifficulties.has(diff);
+        return (
+          <button
+            key={diff}
+            onClick={() => handleDifficultyToggle(diff)}
+            className={`px-3 py-1.5 text-sm font-medium rounded-full border transition-all ${
+              isSelected ? cfg.selected : cfg.unselected
+            }`}
+          >
+            {t(cfg.tKey)}
+          </button>
+        );
+      })}
+    </div>
+  );
 
   const currentQuestion = questionQueue[currentIndex] ?? null;
 
@@ -192,6 +260,7 @@ export default function QuizPage({ params }: QuizPageProps) {
   return (
     <main className="container mx-auto px-4 py-8">
       <div className="max-w-3xl mx-auto">
+        {difficultyFilter}
         {currentQuestion && (
           <QuestionComponent
             questionData={currentQuestion}

--- a/src/app/quiz/[topicId]/page.tsx
+++ b/src/app/quiz/[topicId]/page.tsx
@@ -42,6 +42,8 @@ export default function QuizPage({ params }: QuizPageProps) {
   // 에러 핸들러용 스냅샷 동기화
   queueSnapshotRef.current = { queueLen: questionQueue.length, idx: currentIndex };
 
+  const abortControllerRef = useRef<AbortController | null>(null);
+
   const fetchBatch = useCallback(async () => {
     if (isFetchingRef.current || noMoreQuestionsRef.current) return;
     isFetchingRef.current = true;
@@ -53,8 +55,14 @@ export default function QuizPage({ params }: QuizPageProps) {
       const diffParam = selectedDifficulties.size < 3
         ? `&difficulty=${difficultyParam}`
         : '';
+
+      abortControllerRef.current?.abort();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
       const res = await fetch(
-        `/api/questions/${params.topicId}?count=${BATCH_SIZE}${excludeParam}${diffParam}`
+        `/api/questions/${params.topicId}?count=${BATCH_SIZE}${excludeParam}${diffParam}`,
+        { signal: controller.signal }
       );
       if (!res.ok) {
         throw new Error('quiz.errorLoad');
@@ -69,6 +77,7 @@ export default function QuizPage({ params }: QuizPageProps) {
       }
       setQuestionQueue((prev) => [...prev, ...data]);
     } catch (err: any) {
+      if (err.name === 'AbortError') return;
       setError((prevError) => {
         const { queueLen, idx } = queueSnapshotRef.current;
         if (queueLen > idx) return prevError;
@@ -81,6 +90,7 @@ export default function QuizPage({ params }: QuizPageProps) {
   }, [params.topicId, difficultyParam]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
+    abortControllerRef.current?.abort();
     setQuestionQueue([]);
     setCurrentIndex(0);
     seenIdsRef.current = new Set();
@@ -177,6 +187,7 @@ export default function QuizPage({ params }: QuizPageProps) {
           <button
             key={diff}
             onClick={() => handleDifficultyToggle(diff)}
+            aria-pressed={isSelected}
             className={`px-3 py-1.5 text-sm font-medium rounded-full border transition-all ${
               isSelected ? cfg.selected : cfg.unselected
             }`}

--- a/src/components/HomeContent.tsx
+++ b/src/components/HomeContent.tsx
@@ -84,6 +84,13 @@ export default function HomeContent({ topics, dailySetId }: HomeContentProps) {
                 {topic.questionCount != null && (
                   <p className="text-sm text-gray-500 dark:text-gray-400">{t('common.questions', { count: topic.questionCount })}</p>
                 )}
+                {topic.difficultyCounts && (
+                  <div className="flex gap-2 mt-1">
+                    <span className="text-xs font-medium text-green-600 dark:text-green-400">E {topic.difficultyCounts.EASY}</span>
+                    <span className="text-xs font-medium text-orange-500 dark:text-orange-400">M {topic.difficultyCounts.MEDIUM}</span>
+                    <span className="text-xs font-medium text-red-600 dark:text-red-400">H {topic.difficultyCounts.HARD}</span>
+                  </div>
+                )}
               </div>
             </div>
           </Link>

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -53,6 +53,8 @@ const en = {
     difficultyEasy: 'Easy',
     difficultyMedium: 'Medium',
     difficultyHard: 'Hard',
+    difficultyAll: 'All',
+    difficultyFilter: 'Difficulty',
   },
   leaderboard: {
     title: 'Leaderboard',

--- a/src/lib/translations/ko.ts
+++ b/src/lib/translations/ko.ts
@@ -53,6 +53,8 @@ const ko = {
     difficultyEasy: '쉬움',
     difficultyMedium: '보통',
     difficultyHard: '어려움',
+    difficultyAll: '전체',
+    difficultyFilter: '난이도',
   },
   leaderboard: {
     title: '리더보드',

--- a/src/types/quizTypes.ts
+++ b/src/types/quizTypes.ts
@@ -35,6 +35,7 @@ export interface Topic {
   name_ko: string;
   name_en: string;
   questionCount?: number;
+  difficultyCounts?: { EASY: number; MEDIUM: number; HARD: number };
 }
 
 export interface LeaderboardEntry {


### PR DESCRIPTION
## 요약
토픽 퀴즈에서 EASY/MEDIUM/HARD 난이도를 선택할 수 있는 필터 UI를 추가한다. (closes #37)

## 변경 내용
- **타입/번역**: `Topic`에 `difficultyCounts` 필드 추가, 필터 관련 번역 키 추가
- **API**: `/api/questions/[topicId]`에 `?difficulty=EASY,MEDIUM` 쿼리 파라미터 지원
- **홈 페이지**: 토픽 카드에 난이도별 문제 수 표시 (`E 45 M 72 H 15`, 초록/주황/빨강)
- **퀴즈 페이지**: 상단에 쉬움/보통/어려움 토글 필 버튼 (다중 선택, 최소 1개 유지, 변경 시 큐 리셋)

## 테스트
- [ ] 홈 페이지: 토픽 카드에 E/M/H 카운트가 올바르게 표시되는지 확인
- [ ] 퀴즈 페이지: 필터 필 토글 시 해당 난이도 문제만 출제되는지 확인
- [ ] 퀴즈 페이지: 마지막 1개 난이도는 해제 불가한지 확인
- [ ] 랜덤 퀴즈에서도 필터 동작 확인
- [ ] 다크 모드 / 언어 전환 시 UI 정상 렌더링 확인
- [ ] `npm run build` 통과 확인 (완료)