### PR TITLE
feat: 난이도 필터 UX 개선 (localStorage + URL 동기화)

### DIFF
--- a/src/app/quiz/[topicId]/page.tsx
+++ b/src/app/quiz/[topicId]/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { QuestionData } from '@/types/quizTypes';
 import { useAuth } from '@/contexts/AuthContext';
 import { useLanguage } from '@/contexts/LanguageContext';
 import QuestionComponent from '@/components/QuestionComponent';
+import { useDifficultyFilter } from '@/hooks/useDifficultyFilter';
 
 const BATCH_SIZE = 10;
 const PREFETCH_THRESHOLD = 3;
@@ -16,7 +17,7 @@ interface QuizPageProps {
   };
 }
 
-export default function QuizPage({ params }: QuizPageProps) {
+function QuizPageContent({ params }: QuizPageProps) {
   const router = useRouter();
   const { user } = useAuth();
   const { t } = useLanguage();
@@ -34,10 +35,7 @@ export default function QuizPage({ params }: QuizPageProps) {
   const seenIdsRef = useRef<Set<string>>(new Set());
   const noMoreQuestionsRef = useRef(false);
 
-  const [selectedDifficulties, setSelectedDifficulties] = useState<Set<string>>(
-    new Set(['EASY', 'MEDIUM', 'HARD'])
-  );
-  const difficultyParam = Array.from(selectedDifficulties).sort().join(',');
+  const { selectedDifficulties, difficultyParam, handleDifficultyToggle } = useDifficultyFilter();
 
   // 에러 핸들러용 스냅샷 동기화
   queueSnapshotRef.current = { queueLen: questionQueue.length, idx: currentIndex };
@@ -52,7 +50,7 @@ export default function QuizPage({ params }: QuizPageProps) {
       const excludeParam = seenIdsRef.current.size > 0
         ? `&exclude=${Array.from(seenIdsRef.current).join(',')}`
         : '';
-      const diffParam = selectedDifficulties.size < 3
+      const diffParam = difficultyParam
         ? `&difficulty=${difficultyParam}`
         : '';
 
@@ -123,19 +121,6 @@ export default function QuizPage({ params }: QuizPageProps) {
     if (isCorrect) {
       setCorrectCount((prev) => prev + 1);
     }
-  };
-
-  const handleDifficultyToggle = (difficulty: string) => {
-    setSelectedDifficulties((prev) => {
-      const next = new Set(prev);
-      if (next.has(difficulty)) {
-        if (next.size === 1) return prev; // 최소 1개 유지
-        next.delete(difficulty);
-      } else {
-        next.add(difficulty);
-      }
-      return next;
-    });
   };
 
   const handleQuit = async () => {
@@ -282,5 +267,17 @@ export default function QuizPage({ params }: QuizPageProps) {
         )}
       </div>
     </main>
+  );
+}
+
+export default function QuizPage({ params }: QuizPageProps) {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-xl text-gray-600 animate-pulse">Loading...</p>
+      </div>
+    }>
+      <QuizPageContent params={params} />
+    </Suspense>
   );
 }

--- a/src/app/quiz/[topicId]/page.tsx
+++ b/src/app/quiz/[topicId]/page.tsx
@@ -271,10 +271,11 @@ function QuizPageContent({ params }: QuizPageProps) {
 }
 
 export default function QuizPage({ params }: QuizPageProps) {
+  const { t } = useLanguage();
   return (
     <Suspense fallback={
       <div className="min-h-screen flex items-center justify-center">
-        <p className="text-xl text-gray-600 animate-pulse">Loading...</p>
+        <p className="text-xl text-gray-600 animate-pulse">{t('quiz.loading')}</p>
       </div>
     }>
       <QuizPageContent params={params} />

--- a/src/hooks/useDifficultyFilter.ts
+++ b/src/hooks/useDifficultyFilter.ts
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+const STORAGE_KEY = 'cs-quiz-difficulty-filter';
+const ALL_DIFFICULTIES = ['EASY', 'MEDIUM', 'HARD'] as const;
+
+function readFromStorage(): Set<string> | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return null;
+    const parsed = stored
+      .split(',')
+      .map((d) => d.trim())
+      .filter((d) => (ALL_DIFFICULTIES as readonly string[]).includes(d));
+    return parsed.length > 0 ? new Set(parsed) : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveToStorage(difficulties: Set<string>) {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, Array.from(difficulties).sort().join(','));
+  } catch {
+    // storage full or blocked — ignore
+  }
+}
+
+function syncToUrl(difficulties: Set<string>) {
+  if (typeof window === 'undefined') return;
+  const url = new URL(window.location.href);
+  if (difficulties.size === ALL_DIFFICULTIES.length) {
+    url.searchParams.delete('difficulty');
+  } else {
+    url.searchParams.set('difficulty', Array.from(difficulties).sort().join(','));
+  }
+  window.history.replaceState(null, '', url.toString());
+}
+
+function resolveInitial(searchParams: URLSearchParams): Set<string> {
+  // 1. URL param
+  const urlParam = searchParams.get('difficulty');
+  if (urlParam) {
+    const fromUrl = urlParam
+      .split(',')
+      .map((d) => d.trim())
+      .filter((d) => (ALL_DIFFICULTIES as readonly string[]).includes(d));
+    if (fromUrl.length > 0) return new Set(fromUrl);
+  }
+
+  // 2. localStorage
+  const fromStorage = readFromStorage();
+  if (fromStorage) return fromStorage;
+
+  // 3. default
+  return new Set(ALL_DIFFICULTIES);
+}
+
+export function useDifficultyFilter() {
+  const searchParams = useSearchParams();
+  const [selectedDifficulties, setSelectedDifficulties] = useState<Set<string>>(
+    () => resolveInitial(searchParams)
+  );
+
+  const difficultyParam = Array.from(selectedDifficulties).sort().join(',');
+
+  const handleDifficultyToggle = useCallback((difficulty: string) => {
+    setSelectedDifficulties((prev) => {
+      const next = new Set(prev);
+      if (next.has(difficulty)) {
+        if (next.size === 1) return prev; // 최소 1개 유지
+        next.delete(difficulty);
+      } else {
+        next.add(difficulty);
+      }
+      saveToStorage(next);
+      syncToUrl(next);
+      return next;
+    });
+  }, []);
+
+  return { selectedDifficulties, difficultyParam, handleDifficultyToggle };
+}

--- a/src/hooks/useDifficultyFilter.ts
+++ b/src/hooks/useDifficultyFilter.ts
@@ -73,11 +73,16 @@ export function useDifficultyFilter() {
 
   const handleDifficultyToggle = useCallback((difficulty: string) => {
     setSelectedDifficulties((prev) => {
-      const next = new Set(prev);
-      if (next.has(difficulty)) {
-        if (next.size === 1) return prev; // 최소 1개 유지
+      let next: Set<string>;
+      if (prev.size === ALL_DIFFICULTIES.length) {
+        // 전체 선택 상태에서 클릭 → 해당 필터만 켜기
+        next = new Set([difficulty]);
+      } else if (prev.has(difficulty)) {
+        if (prev.size === 1) return prev; // 최소 1개 유지
+        next = new Set(prev);
         next.delete(difficulty);
       } else {
+        next = new Set(prev);
         next.add(difficulty);
       }
       saveToStorage(next);

--- a/src/hooks/useDifficultyFilter.ts
+++ b/src/hooks/useDifficultyFilter.ts
@@ -66,7 +66,10 @@ export function useDifficultyFilter() {
     () => resolveInitial(searchParams)
   );
 
-  const difficultyParam = Array.from(selectedDifficulties).sort().join(',');
+  const difficultyParam =
+    selectedDifficulties.size === ALL_DIFFICULTIES.length
+      ? ''
+      : Array.from(selectedDifficulties).sort().join(',');
 
   const handleDifficultyToggle = useCallback((difficulty: string) => {
     setSelectedDifficulties((prev) => {


### PR DESCRIPTION
## 요약
- 퀴즈 페이지 난이도 필터 선택이 페이지 이탈 시 초기화되는 문제 해결
- localStorage로 선호도 기억 + URL 쿼리 파라미터로 필터 공유 가능

## 변경 내용
- `src/hooks/useDifficultyFilter.ts` 신규 — 난이도 필터 상태 관리 커스텀 훅
  - 초기화 우선순위: URL `?difficulty=` → localStorage → 기본값(전체)
  - 변경 시 React state + localStorage + URL(`history.replaceState`) 동기화
- `src/app/quiz/[topicId]/page.tsx` 수정 — 인라인 상태/핸들러를 훅으로 교체
  - `useSearchParams` 사용을 위한 Suspense boundary 추가
  - Suspense fallback에 번역 시스템 적용

## 테스트
- [x] `npm run check` (lint + type-check) 통과
- [x] `npm run build` 프로덕션 빌드 성공
- [ ] `/quiz/database` 첫 방문 → 전체 선택 확인
- [ ] HARD 해제 후 재방문 → EASY+MEDIUM 복원 확인
- [ ] `/quiz/database?difficulty=HARD` → HARD만 선택 확인
- [ ] 전체 선택 시 URL에서 difficulty 파라미터 제거 확인