### PR TITLE
feat: 오답 노트 및 복습 모드 (#36)

### DIFF
--- a/prisma/migrations/20260425042045_add_wrong_notes/migration.sql
+++ b/prisma/migrations/20260425042045_add_wrong_notes/migration.sql
@@ -1,0 +1,44 @@
+/*
+  Warnings:
+
+  - The primary key for the `_ConceptToQuestion` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - A unique constraint covering the columns `[A,B]` on the table `_ConceptToQuestion` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateEnum
+CREATE TYPE "WrongNoteStatus" AS ENUM ('ACTIVE', 'RESOLVED');
+
+-- AlterTable
+ALTER TABLE "QuizSession" ADD COLUMN     "wrongQuestionIds" TEXT[];
+
+-- AlterTable
+ALTER TABLE "_ConceptToQuestion" DROP CONSTRAINT "_ConceptToQuestion_AB_pkey";
+
+-- CreateTable
+CREATE TABLE "WrongNote" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "questionId" TEXT NOT NULL,
+    "status" "WrongNoteStatus" NOT NULL DEFAULT 'ACTIVE',
+    "wrongCount" INTEGER NOT NULL DEFAULT 1,
+    "consecutiveCorrect" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "resolvedAt" TIMESTAMP(3),
+
+    CONSTRAINT "WrongNote_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "WrongNote_userId_status_idx" ON "WrongNote"("userId", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WrongNote_userId_questionId_key" ON "WrongNote"("userId", "questionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_ConceptToQuestion_AB_unique" ON "_ConceptToQuestion"("A", "B");
+
+-- AddForeignKey
+ALTER TABLE "WrongNote" ADD CONSTRAINT "WrongNote_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WrongNote" ADD CONSTRAINT "WrongNote_questionId_fkey" FOREIGN KEY ("questionId") REFERENCES "Question"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,6 +48,7 @@ model Question {
   answerOptions AnswerOption[]
   feedbacks     Feedback[]
   concepts      Concept[]
+  wrongNotes    WrongNote[]
 }
 
 model AnswerOption {
@@ -67,6 +68,7 @@ model User {
   createdAt    DateTime      @default(now())
   scores       UserScore[]
   quizSessions QuizSession[]
+  wrongNotes   WrongNote[]
 }
 
 model DailyQuestionSet {
@@ -105,9 +107,10 @@ model QuizSession {
   solvedCount  Int
   correctCount Int
   timeSpent    Int      // seconds
-  completedAt  DateTime @default(now())
+  completedAt      DateTime @default(now())
+  wrongQuestionIds String[]
 
-  user         User     @relation(fields: [userId], references: [id])
+  user             User     @relation(fields: [userId], references: [id])
 
   @@index([userId, completedAt])
   @@index([completedAt])
@@ -124,4 +127,26 @@ model Feedback {
   question   Question? @relation(fields: [questionId], references: [id])
 
   @@index([questionId])
+}
+
+enum WrongNoteStatus {
+  ACTIVE
+  RESOLVED
+}
+
+model WrongNote {
+  id                 String          @id @default(cuid())
+  userId             String
+  questionId         String
+  status             WrongNoteStatus @default(ACTIVE)
+  wrongCount         Int             @default(1)
+  consecutiveCorrect Int             @default(0)
+  createdAt          DateTime        @default(now())
+  resolvedAt         DateTime?
+
+  user               User            @relation(fields: [userId], references: [id])
+  question           Question        @relation(fields: [questionId], references: [id])
+
+  @@unique([userId, questionId])
+  @@index([userId, status])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -108,7 +108,7 @@ model QuizSession {
   correctCount Int
   timeSpent    Int      // seconds
   completedAt      DateTime @default(now())
-  wrongQuestionIds String[]
+  wrongQuestionIds String[] @default([])
 
   user             User     @relation(fields: [userId], references: [id])
 

--- a/src/app/api/quiz-session/route.ts
+++ b/src/app/api/quiz-session/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: Request) {
       );
     }
 
-    const { quizType, topicId, dailySetId, solvedCount, correctCount, timeSpent } =
+    const { quizType, topicId, dailySetId, solvedCount, correctCount, timeSpent, wrongQuestionIds } =
       await request.json();
 
     if (!quizType || solvedCount == null || correctCount == null || timeSpent == null) {
@@ -43,8 +43,35 @@ export async function POST(request: Request) {
         solvedCount,
         correctCount,
         timeSpent,
+        wrongQuestionIds: wrongQuestionIds || [],
       },
     });
+
+    // WrongNote upsert: 틀린 문제 기록
+    if (wrongQuestionIds && wrongQuestionIds.length > 0) {
+      await Promise.all(
+        wrongQuestionIds.map((questionId: string) =>
+          prisma.wrongNote.upsert({
+            where: {
+              userId_questionId: { userId, questionId },
+            },
+            create: {
+              userId,
+              questionId,
+              status: 'ACTIVE',
+              wrongCount: 1,
+              consecutiveCorrect: 0,
+            },
+            update: {
+              status: 'ACTIVE',
+              wrongCount: { increment: 1 },
+              consecutiveCorrect: 0,
+              resolvedAt: null,
+            },
+          })
+        )
+      );
+    }
 
     return NextResponse.json({ id: session.id });
   } catch (error) {

--- a/src/app/api/wrong-notes/review-result/route.ts
+++ b/src/app/api/wrong-notes/review-result/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { cookies } from "next/headers";
+
+const GRADUATE_THRESHOLD = 3;
+
+export async function POST(request: Request) {
+  try {
+    const userId = cookies().get("userId")?.value;
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 401 });
+    }
+
+    const { results } = await request.json();
+
+    if (!results || !Array.isArray(results)) {
+      return NextResponse.json({ error: "Missing results array" }, { status: 400 });
+    }
+
+    let graduated = 0;
+    let reset = 0;
+
+    await Promise.all(
+      results.map(async ({ questionId, correct }: { questionId: string; correct: boolean }) => {
+        const note = await prisma.wrongNote.findUnique({
+          where: { userId_questionId: { userId, questionId } },
+        });
+
+        if (!note) return;
+
+        if (correct) {
+          const newConsecutive = note.consecutiveCorrect + 1;
+          if (newConsecutive >= GRADUATE_THRESHOLD) {
+            await prisma.wrongNote.update({
+              where: { id: note.id },
+              data: {
+                consecutiveCorrect: newConsecutive,
+                status: "RESOLVED",
+                resolvedAt: new Date(),
+              },
+            });
+            graduated++;
+          } else {
+            await prisma.wrongNote.update({
+              where: { id: note.id },
+              data: { consecutiveCorrect: newConsecutive },
+            });
+          }
+        } else {
+          await prisma.wrongNote.update({
+            where: { id: note.id },
+            data: {
+              consecutiveCorrect: 0,
+              wrongCount: { increment: 1 },
+            },
+          });
+          reset++;
+        }
+      })
+    );
+
+    return NextResponse.json({ graduated, reset });
+  } catch (error) {
+    console.error("Failed to process review result:", error);
+    return NextResponse.json({ error: "Failed to process review result" }, { status: 500 });
+  }
+}

--- a/src/app/api/wrong-notes/review-result/route.ts
+++ b/src/app/api/wrong-notes/review-result/route.ts
@@ -13,7 +13,9 @@ export async function POST(request: Request) {
 
     const user = await prisma.user.findUnique({ where: { id: userId } });
     if (!user) {
-      return NextResponse.json({ error: "User not found" }, { status: 401 });
+      const response = NextResponse.json({ error: "User not found" }, { status: 401 });
+      response.cookies.delete("userId");
+      return response;
     }
 
     const { results } = await request.json();

--- a/src/app/api/wrong-notes/route.ts
+++ b/src/app/api/wrong-notes/route.ts
@@ -22,6 +22,11 @@ export async function GET(request: NextRequest) {
     const status = searchParams.get("status") || "ACTIVE";
     const topicId = searchParams.get("topicId");
 
+    const validStatuses = ["ACTIVE", "RESOLVED", "ALL"];
+    if (!validStatuses.includes(status)) {
+      return NextResponse.json({ error: "Invalid status" }, { status: 400 });
+    }
+
     const where: Record<string, unknown> = { userId };
 
     if (status !== "ALL") {

--- a/src/app/api/wrong-notes/route.ts
+++ b/src/app/api/wrong-notes/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { cookies } from "next/headers";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  try {
+    const userId = cookies().get("userId")?.value;
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    if (!user) {
+      const response = NextResponse.json({ error: "User not found" }, { status: 401 });
+      response.cookies.delete("userId");
+      return response;
+    }
+
+    const { searchParams } = request.nextUrl;
+    const status = searchParams.get("status") || "ACTIVE";
+    const topicId = searchParams.get("topicId");
+
+    const where: Record<string, unknown> = { userId };
+
+    if (status !== "ALL") {
+      where.status = status;
+    }
+
+    if (topicId) {
+      where.question = { topicId };
+    }
+
+    const wrongNotes = await prisma.wrongNote.findMany({
+      where,
+      include: {
+        question: {
+          include: {
+            topic: { select: { id: true, name_ko: true, name_en: true } },
+            answerOptions: true,
+          },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    const notes = wrongNotes.map((note) => ({
+      id: note.id,
+      questionId: note.questionId,
+      status: note.status,
+      wrongCount: note.wrongCount,
+      consecutiveCorrect: note.consecutiveCorrect,
+      createdAt: note.createdAt,
+      resolvedAt: note.resolvedAt,
+      question: {
+        id: note.question.id,
+        topicId: note.question.topicId,
+        question_ko: note.question.text_ko,
+        question_en: note.question.text_en,
+        hint_ko: note.question.hint_ko,
+        hint_en: note.question.hint_en,
+        difficulty: note.question.difficulty,
+        topic: note.question.topic,
+        answerOptions: note.question.answerOptions,
+      },
+    }));
+
+    return NextResponse.json(notes);
+  } catch (error) {
+    console.error("Failed to get wrong notes:", error);
+    return NextResponse.json({ error: "Failed to get wrong notes" }, { status: 500 });
+  }
+}

--- a/src/app/api/wrong-notes/summary/route.ts
+++ b/src/app/api/wrong-notes/summary/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { cookies } from "next/headers";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const userId = cookies().get("userId")?.value;
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    if (!user) {
+      const response = NextResponse.json({ error: "User not found" }, { status: 401 });
+      response.cookies.delete("userId");
+      return response;
+    }
+
+    const [activeCount, resolvedCount] = await Promise.all([
+      prisma.wrongNote.count({ where: { userId, status: "ACTIVE" } }),
+      prisma.wrongNote.count({ where: { userId, status: "RESOLVED" } }),
+    ]);
+
+    const byTopicRaw = await prisma.wrongNote.findMany({
+      where: { userId, status: "ACTIVE" },
+      select: {
+        question: {
+          select: {
+            topic: { select: { id: true, name_ko: true, name_en: true } },
+          },
+        },
+      },
+    });
+
+    const topicCountMap = new Map<string, { name_ko: string; name_en: string; count: number }>();
+    for (const note of byTopicRaw) {
+      const topic = note.question.topic;
+      const existing = topicCountMap.get(topic.id);
+      if (existing) {
+        existing.count++;
+      } else {
+        topicCountMap.set(topic.id, { name_ko: topic.name_ko, name_en: topic.name_en, count: 1 });
+      }
+    }
+
+    const byTopic = Array.from(topicCountMap.entries())
+      .map(([topicId, data]) => ({ topicId, ...data }))
+      .sort((a, b) => b.count - a.count);
+
+    return NextResponse.json({ activeCount, resolvedCount, byTopic });
+  } catch (error) {
+    console.error("Failed to get wrong notes summary:", error);
+    return NextResponse.json({ error: "Failed to get wrong notes summary" }, { status: 500 });
+  }
+}

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -46,6 +46,7 @@ export default function DailyQuizPage() {
   const [scoreSubmitError, setScoreSubmitError] = useState<string | null>(null);
   const [pendingScoreSubmit, setPendingScoreSubmit] = useState(false);
   const [isSubmittingScore, setIsSubmittingScore] = useState(false);
+  const wrongQuestionIdsRef = useRef<string[]>([]);
   const isTransitioning = useRef(false);
 
   useEffect(() => {
@@ -70,9 +71,11 @@ export default function DailyQuizPage() {
     fetchDailyQuestions();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleAnswer = useCallback((isCorrect: boolean) => {
+  const handleAnswer = useCallback((isCorrect: boolean, questionId: string) => {
     if (isCorrect) {
       setCorrectAnswers(prev => prev + 1);
+    } else {
+      wrongQuestionIdsRef.current.push(questionId);
     }
   }, []);
 
@@ -91,6 +94,7 @@ export default function DailyQuizPage() {
           solvedCount: questions.length,
           correctCount: correctAnswers,
           timeSpent,
+          wrongQuestionIds: wrongQuestionIdsRef.current,
         }),
       }).catch((err) => { console.warn('Failed to save quiz session:', err); });
 

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -79,6 +79,29 @@ export default function DailyQuizPage() {
     }
   }, []);
 
+  const handleQuit = useCallback(async () => {
+    if (user && currentIndex > 0) {
+      const timeSpent = Math.floor((Date.now() - startTime) / 1000);
+      try {
+        await fetch('/api/quiz-session', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            quizType: 'daily',
+            dailySetId,
+            solvedCount: currentIndex,
+            correctCount: correctAnswers,
+            timeSpent,
+            wrongQuestionIds: wrongQuestionIdsRef.current,
+          }),
+        });
+      } catch {
+        // 저장 실패해도 홈으로 이동
+      }
+    }
+    router.push('/');
+  }, [user, currentIndex, correctAnswers, startTime, dailySetId, router]);
+
   const submitScore = useCallback(async () => {
     const timeSpent = Math.floor((Date.now() - startTime) / 1000);
     setScoreSubmitError(null);
@@ -360,7 +383,7 @@ export default function DailyQuizPage() {
             </p>
           </div>
           <button
-            onClick={() => router.push('/')}
+            onClick={handleQuit}
             className="px-4 py-2 text-gray-600 hover:text-gray-800 transition-colors font-medium"
           >
             {t('daily.quit')}

--- a/src/app/quiz/[topicId]/page.tsx
+++ b/src/app/quiz/[topicId]/page.tsx
@@ -33,6 +33,7 @@ function QuizPageContent({ params }: QuizPageProps) {
   const [correctCount, setCorrectCount] = useState(0);
   const [showStatTooltip, setShowStatTooltip] = useState(false);
   const seenIdsRef = useRef<Set<string>>(new Set());
+  const wrongQuestionIdsRef = useRef<string[]>([]);
   const noMoreQuestionsRef = useRef(false);
 
   const { selectedDifficulties, difficultyParam, handleDifficultyToggle } = useDifficultyFilter();
@@ -95,6 +96,7 @@ function QuizPageContent({ params }: QuizPageProps) {
     noMoreQuestionsRef.current = false;
     setSolvedCount(0);
     setCorrectCount(0);
+    wrongQuestionIdsRef.current = [];
     setError(null);
     setLoading(true);
     isFetchingRef.current = false;
@@ -116,10 +118,12 @@ function QuizPageContent({ params }: QuizPageProps) {
     requestAnimationFrame(() => { isTransitioning.current = false; });
   };
 
-  const handleAnswer = (isCorrect: boolean) => {
+  const handleAnswer = (isCorrect: boolean, questionId: string) => {
     setSolvedCount((prev) => prev + 1);
     if (isCorrect) {
       setCorrectCount((prev) => prev + 1);
+    } else {
+      wrongQuestionIdsRef.current.push(questionId);
     }
   };
 
@@ -136,6 +140,7 @@ function QuizPageContent({ params }: QuizPageProps) {
             solvedCount,
             correctCount,
             timeSpent,
+            wrongQuestionIds: wrongQuestionIdsRef.current,
           }),
         });
       } catch {

--- a/src/app/quiz/review/page.tsx
+++ b/src/app/quiz/review/page.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { QuestionData } from '@/types/quizTypes';
+import { useAuth } from '@/contexts/AuthContext';
+import { useLanguage } from '@/contexts/LanguageContext';
+import QuestionComponent from '@/components/QuestionComponent';
+
+interface ReviewResult {
+  questionId: string;
+  correct: boolean;
+}
+
+function ReviewQuizContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const topicId = searchParams.get('topicId');
+  const { user } = useAuth();
+  const { t } = useLanguage();
+
+  const [questions, setQuestions] = useState<QuestionData[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [solvedCount, setSolvedCount] = useState(0);
+  const [correctCount, setCorrectCount] = useState(0);
+  const startTimeRef = useRef(Date.now());
+  const reviewResultsRef = useRef<ReviewResult[]>([]);
+  const [showStatTooltip, setShowStatTooltip] = useState(false);
+
+  const fetchWrongNotes = useCallback(async () => {
+    try {
+      const topicParam = topicId ? `&topicId=${topicId}` : '';
+      const res = await fetch(`/api/wrong-notes?status=ACTIVE${topicParam}`);
+      if (!res.ok) throw new Error('Failed to load wrong notes');
+      const notes = await res.json();
+      const questionList: QuestionData[] = notes.map((note: { question: QuestionData }) => note.question);
+      // Shuffle
+      for (let i = questionList.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [questionList[i], questionList[j]] = [questionList[j], questionList[i]];
+      }
+      setQuestions(questionList);
+      if (questionList.length === 0) {
+        setError('wrongNotes.reviewEmpty');
+      }
+    } catch {
+      setError('common.error');
+    } finally {
+      setLoading(false);
+    }
+  }, [topicId]);
+
+  useEffect(() => {
+    fetchWrongNotes();
+  }, [fetchWrongNotes]);
+
+  const isTransitioning = useRef(false);
+  const handleNextQuestion = () => {
+    if (isTransitioning.current) return;
+    isTransitioning.current = true;
+
+    if (currentIndex + 1 >= questions.length) {
+      handleQuit();
+      return;
+    }
+
+    setCurrentIndex((prev) => prev + 1);
+    requestAnimationFrame(() => { isTransitioning.current = false; });
+  };
+
+  const handleAnswer = (isCorrect: boolean, questionId: string) => {
+    setSolvedCount((prev) => prev + 1);
+    if (isCorrect) {
+      setCorrectCount((prev) => prev + 1);
+    }
+    reviewResultsRef.current.push({ questionId, correct: isCorrect });
+  };
+
+  const handleQuit = async () => {
+    if (user && solvedCount > 0) {
+      const timeSpent = Math.round((Date.now() - startTimeRef.current) / 1000);
+      const wrongQuestionIds = reviewResultsRef.current
+        .filter((r) => !r.correct)
+        .map((r) => r.questionId);
+
+      try {
+        await Promise.all([
+          fetch('/api/quiz-session', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              quizType: 'review',
+              topicId: topicId || null,
+              solvedCount,
+              correctCount,
+              timeSpent,
+              wrongQuestionIds,
+            }),
+          }),
+          fetch('/api/wrong-notes/review-result', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ results: reviewResultsRef.current }),
+          }),
+        ]);
+      } catch {
+        // 저장 실패해도 이동
+      }
+    }
+    router.push('/wrong-notes');
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-xl text-gray-600 animate-pulse">{t('common.loading')}</p>
+      </div>
+    );
+  }
+
+  if (error || questions.length === 0) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-xl text-gray-600 dark:text-gray-400 mb-4">{t(error || 'wrongNotes.reviewEmpty')}</p>
+          <button onClick={() => router.push('/wrong-notes')} className="px-6 py-3 bg-gradient-to-r from-orange-500 to-amber-500 text-white rounded-lg font-semibold shadow-md">
+            {t('wrongNotes.title')}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const currentQuestion = questions[currentIndex] ?? null;
+
+  const handleStatTap = () => {
+    setShowStatTooltip(true);
+    setTimeout(() => setShowStatTooltip(false), 2000);
+  };
+
+  const pillClass = "px-4 py-2 bg-gray-100 hover:bg-gray-200 rounded-full transition-colors text-sm font-medium";
+
+  const quizFooter = (
+    <div className="flex items-center gap-2">
+      {solvedCount > 0 && (
+        <div className="relative">
+          <button onClick={handleStatTap} className={pillClass}>
+            <span className="text-green-600 font-bold">{correctCount}</span>
+            <span className="text-gray-400"> / </span>
+            <span className="text-gray-600">{solvedCount}</span>
+          </button>
+          {showStatTooltip && (
+            <div className="absolute bottom-full right-0 mb-2 px-3 py-1.5 bg-gray-800 text-white text-xs rounded-lg whitespace-nowrap shadow-lg animate-in fade-in duration-200">
+              {t('quiz.correctSlashSolved')}
+              <div className="absolute top-full right-4 w-0 h-0 border-x-4 border-x-transparent border-t-4 border-t-gray-800" />
+            </div>
+          )}
+        </div>
+      )}
+      <span className={`${pillClass} text-gray-400 pointer-events-none`}>
+        {currentIndex + 1} / {questions.length}
+      </span>
+      <button onClick={handleQuit} className={`${pillClass} text-gray-500`}>
+        {t('quiz.quit')}
+      </button>
+    </div>
+  );
+
+  return (
+    <main className="container mx-auto px-4 py-8">
+      <div className="max-w-3xl mx-auto">
+        <div className="mb-4">
+          <span className="px-3 py-1 text-sm font-medium rounded-full bg-red-100 text-red-700 border border-red-300 dark:bg-red-900/30 dark:text-red-400 dark:border-red-700">
+            {t('wrongNotes.reviewMode')}
+          </span>
+        </div>
+
+        {currentQuestion && (
+          <QuestionComponent
+            questionData={currentQuestion}
+            onNextQuestion={handleNextQuestion}
+            onAnswer={handleAnswer}
+            footerRight={quizFooter}
+          />
+        )}
+      </div>
+    </main>
+  );
+}
+
+export default function ReviewQuizPage() {
+  const { t } = useLanguage();
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-xl text-gray-600 animate-pulse">{t('common.loading')}</p>
+      </div>
+    }>
+      <ReviewQuizContent />
+    </Suspense>
+  );
+}

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -50,6 +50,7 @@ export default function StatsPage() {
   const [data, setData] = useState<StatsData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [wrongSummary, setWrongSummary] = useState<{ activeCount: number; resolvedCount: number } | null>(null);
 
   useEffect(() => {
     if (authLoading) return;
@@ -60,10 +61,16 @@ export default function StatsPage() {
 
     async function fetchStats() {
       try {
-        const res = await fetch('/api/stats');
-        if (!res.ok) throw new Error('Failed to fetch stats');
-        const json = await res.json();
+        const [statsRes, wrongRes] = await Promise.all([
+          fetch('/api/stats'),
+          fetch('/api/wrong-notes/summary'),
+        ]);
+        if (!statsRes.ok) throw new Error('Failed to fetch stats');
+        const json = await statsRes.json();
         setData(json);
+        if (wrongRes.ok) {
+          setWrongSummary(await wrongRes.json());
+        }
       } catch {
         setError(t('common.error'));
       } finally {
@@ -218,6 +225,26 @@ export default function StatsPage() {
                   </div>
                 </div>
               ))}
+            </div>
+          </div>
+        )}
+
+        {/* Wrong Notes Summary */}
+        {wrongSummary && wrongSummary.activeCount > 0 && (
+          <div
+            onClick={() => router.push('/wrong-notes')}
+            className="bg-gradient-to-br from-red-50 to-orange-50 dark:from-red-900/20 dark:to-orange-900/20 rounded-xl p-4 md:p-6 shadow-md border border-red-100 dark:border-red-800/30 mb-8 cursor-pointer hover:shadow-lg transition-shadow"
+          >
+            <div className="flex items-center justify-between">
+              <div>
+                <h2 className="text-lg md:text-xl font-bold text-gray-900 dark:text-gray-100 mb-1">{t('wrongNotes.title')}</h2>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  {t('wrongNotes.summaryActive', { count: wrongSummary.activeCount })}
+                </p>
+              </div>
+              <svg className="w-6 h-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
             </div>
           </div>
         )}

--- a/src/app/wrong-notes/page.tsx
+++ b/src/app/wrong-notes/page.tsx
@@ -1,0 +1,276 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { QuestionData } from '@/types/quizTypes';
+
+interface WrongNoteItem {
+  id: string;
+  questionId: string;
+  status: 'ACTIVE' | 'RESOLVED';
+  wrongCount: number;
+  consecutiveCorrect: number;
+  createdAt: string;
+  resolvedAt: string | null;
+  question: QuestionData & {
+    topic: { id: string; name_ko: string; name_en: string };
+  };
+}
+
+interface TopicCount {
+  topicId: string;
+  name_ko: string;
+  name_en: string;
+  count: number;
+}
+
+interface Summary {
+  activeCount: number;
+  resolvedCount: number;
+  byTopic: TopicCount[];
+}
+
+const GRADUATE_THRESHOLD = 3;
+
+export default function WrongNotesPage() {
+  const router = useRouter();
+  const { user, isLoading: authLoading } = useAuth();
+  const { t, language } = useLanguage();
+  const l = (ko: string, en: string) => language === 'en' ? en : ko;
+
+  const [notes, setNotes] = useState<WrongNoteItem[]>([]);
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState<'ACTIVE' | 'RESOLVED'>('ACTIVE');
+  const [selectedTopic, setSelectedTopic] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (authLoading || !user) return;
+
+    async function fetchData() {
+      try {
+        const [notesRes, summaryRes] = await Promise.all([
+          fetch('/api/wrong-notes?status=ALL'),
+          fetch('/api/wrong-notes/summary'),
+        ]);
+        if (notesRes.ok) setNotes(await notesRes.json());
+        if (summaryRes.ok) setSummary(await summaryRes.json());
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, [user, authLoading]);
+
+  if (authLoading || loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-xl text-gray-600 dark:text-gray-400 animate-pulse">{t('common.loading')}</p>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-xl text-gray-600 dark:text-gray-400 mb-4">{t('wrongNotes.loginRequired')}</p>
+          <button onClick={() => router.push('/')} className="px-6 py-3 bg-gradient-to-r from-orange-500 to-amber-500 text-white rounded-lg font-semibold shadow-md">
+            {t('common.goHome')}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const filteredNotes = notes.filter((note) => {
+    if (note.status !== activeTab) return false;
+    if (selectedTopic && note.question.topic.id !== selectedTopic) return false;
+    return true;
+  });
+
+  const canReview = activeTab === 'ACTIVE' && filteredNotes.length > 0;
+
+  const handleReviewStart = () => {
+    const topicParam = selectedTopic ? `?topicId=${selectedTopic}` : '';
+    router.push(`/quiz/review${topicParam}`);
+  };
+
+  const difficultyConfig: Record<string, { tKey: string; classes: string }> = {
+    EASY: { tKey: 'quiz.difficultyEasy', classes: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' },
+    MEDIUM: { tKey: 'quiz.difficultyMedium', classes: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400' },
+    HARD: { tKey: 'quiz.difficultyHard', classes: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' },
+  };
+
+  return (
+    <main className="container mx-auto px-4 py-8 min-h-screen">
+      <div className="max-w-4xl mx-auto">
+        {/* Header */}
+        <div className="flex justify-between items-center mb-8">
+          <h1 className="text-2xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 flex items-center gap-2 md:gap-3">
+            <div className="w-10 h-10 md:w-14 md:h-14 bg-gradient-to-br from-red-400 to-orange-500 rounded-xl md:rounded-2xl flex items-center justify-center shadow-lg">
+              <svg className="w-6 h-6 md:w-8 md:h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+              </svg>
+            </div>
+            {t('wrongNotes.title')}
+          </h1>
+          <button onClick={() => router.push('/')} className="px-4 py-2 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors font-medium">
+            {t('common.homeShort')}
+          </button>
+        </div>
+
+        {/* Summary Cards */}
+        {summary && (
+          <div className="grid grid-cols-2 gap-4 mb-8">
+            <div className="bg-white dark:bg-gray-800 rounded-xl p-4 md:p-6 shadow-md border border-gray-100 dark:border-gray-700 text-center">
+              <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">{t('wrongNotes.tabActive')}</p>
+              <p className="text-2xl md:text-3xl font-bold text-red-600">{summary.activeCount}</p>
+            </div>
+            <div className="bg-white dark:bg-gray-800 rounded-xl p-4 md:p-6 shadow-md border border-gray-100 dark:border-gray-700 text-center">
+              <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">{t('wrongNotes.tabResolved')}</p>
+              <p className="text-2xl md:text-3xl font-bold text-green-600">{summary.resolvedCount}</p>
+            </div>
+          </div>
+        )}
+
+        {/* Empty State */}
+        {notes.length === 0 && (
+          <div className="text-center py-16">
+            <div className="w-20 h-20 mx-auto mb-6 bg-gray-100 dark:bg-gray-800 rounded-full flex items-center justify-center">
+              <svg className="w-10 h-10 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </div>
+            <p className="text-xl text-gray-600 dark:text-gray-400 mb-2">{t('wrongNotes.empty')}</p>
+            <p className="text-sm text-gray-500 dark:text-gray-500 mb-6">{t('wrongNotes.emptyDesc')}</p>
+            <button onClick={() => router.push('/')} className="px-6 py-3 bg-gradient-to-r from-orange-500 to-amber-500 text-white rounded-lg font-semibold shadow-md">
+              {t('common.goHome')}
+            </button>
+          </div>
+        )}
+
+        {notes.length > 0 && (
+          <>
+            {/* Tabs */}
+            <div className="flex gap-2 mb-4">
+              {(['ACTIVE', 'RESOLVED'] as const).map((tab) => (
+                <button
+                  key={tab}
+                  onClick={() => setActiveTab(tab)}
+                  className={`px-4 py-2 rounded-full text-sm font-medium transition-all border ${
+                    activeTab === tab
+                      ? tab === 'ACTIVE'
+                        ? 'bg-red-100 text-red-700 border-red-300 dark:bg-red-900/30 dark:text-red-400 dark:border-red-700'
+                        : 'bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700'
+                      : 'bg-gray-100 text-gray-500 border-gray-200 dark:bg-gray-800 dark:text-gray-500 dark:border-gray-700'
+                  }`}
+                >
+                  {t(`wrongNotes.tab${tab === 'ACTIVE' ? 'Active' : 'Resolved'}`)}
+                </button>
+              ))}
+            </div>
+
+            {/* Topic Filter */}
+            {summary && summary.byTopic.length > 1 && activeTab === 'ACTIVE' && (
+              <div className="flex gap-2 mb-6 flex-wrap">
+                <button
+                  onClick={() => setSelectedTopic(null)}
+                  className={`px-3 py-1.5 text-sm font-medium rounded-full border transition-all ${
+                    !selectedTopic
+                      ? 'bg-orange-100 text-orange-700 border-orange-300 dark:bg-orange-900/30 dark:text-orange-400 dark:border-orange-700'
+                      : 'bg-gray-100 text-gray-400 border-gray-200 dark:bg-gray-800 dark:text-gray-500 dark:border-gray-700'
+                  }`}
+                >
+                  {t('wrongNotes.allTopics')}
+                </button>
+                {summary.byTopic.map((topic) => (
+                  <button
+                    key={topic.topicId}
+                    onClick={() => setSelectedTopic(selectedTopic === topic.topicId ? null : topic.topicId)}
+                    className={`px-3 py-1.5 text-sm font-medium rounded-full border transition-all ${
+                      selectedTopic === topic.topicId
+                        ? 'bg-orange-100 text-orange-700 border-orange-300 dark:bg-orange-900/30 dark:text-orange-400 dark:border-orange-700'
+                        : 'bg-gray-100 text-gray-400 border-gray-200 dark:bg-gray-800 dark:text-gray-500 dark:border-gray-700'
+                    }`}
+                  >
+                    {l(topic.name_ko, topic.name_en)} ({topic.count})
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {/* Review Start Button */}
+            {canReview && (
+              <button
+                onClick={handleReviewStart}
+                className="w-full mb-6 px-6 py-4 bg-gradient-to-r from-red-500 to-orange-500 text-white rounded-xl hover:from-red-600 hover:to-orange-600 transition-all font-semibold shadow-md hover:shadow-lg text-lg"
+              >
+                {t('wrongNotes.reviewStart')} ({filteredNotes.length})
+              </button>
+            )}
+
+            {/* Notes List */}
+            <div className="space-y-3">
+              {filteredNotes.map((note) => {
+                const q = note.question;
+                const diffCfg = difficultyConfig[q.difficulty] || difficultyConfig.MEDIUM;
+                return (
+                  <div key={note.id} className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border border-gray-100 dark:border-gray-700">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-2 flex-wrap">
+                          <span className={`px-2 py-0.5 text-xs font-medium rounded-full ${diffCfg.classes}`}>
+                            {t(diffCfg.tKey)}
+                          </span>
+                          <span className="text-xs text-gray-500 dark:text-gray-400">
+                            {l(q.topic.name_ko, q.topic.name_en)}
+                          </span>
+                        </div>
+                        <p className="text-gray-800 dark:text-gray-200 line-clamp-2">
+                          {l(q.question_ko, q.question_en)}
+                        </p>
+                      </div>
+                      <div className="text-right shrink-0">
+                        <p className="text-sm text-red-500 font-medium">
+                          {t('wrongNotes.wrongCount', { count: note.wrongCount })}
+                        </p>
+                        {note.status === 'ACTIVE' && (
+                          <div className="flex items-center gap-1 mt-1 justify-end">
+                            {Array.from({ length: GRADUATE_THRESHOLD }).map((_, i) => (
+                              <div
+                                key={i}
+                                className={`w-2.5 h-2.5 rounded-full ${
+                                  i < note.consecutiveCorrect
+                                    ? 'bg-green-500'
+                                    : 'bg-gray-200 dark:bg-gray-600'
+                                }`}
+                              />
+                            ))}
+                          </div>
+                        )}
+                        {note.status === 'RESOLVED' && (
+                          <p className="text-sm text-green-600 font-medium mt-1">
+                            {t('wrongNotes.graduated')}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {filteredNotes.length === 0 && (
+              <div className="text-center py-12">
+                <p className="text-gray-500 dark:text-gray-400">{t('wrongNotes.reviewEmpty')}</p>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/wrong-notes/page.tsx
+++ b/src/app/wrong-notes/page.tsx
@@ -47,7 +47,11 @@ export default function WrongNotesPage() {
   const [selectedTopic, setSelectedTopic] = useState<string | null>(null);
 
   useEffect(() => {
-    if (authLoading || !user) return;
+    if (authLoading) return;
+    if (!user) {
+      setLoading(false);
+      return;
+    }
 
     async function fetchData() {
       try {
@@ -87,7 +91,7 @@ export default function WrongNotesPage() {
 
   const filteredNotes = notes.filter((note) => {
     if (note.status !== activeTab) return false;
-    if (selectedTopic && note.question.topic.id !== selectedTopic) return false;
+    if (activeTab === 'ACTIVE' && selectedTopic && note.question.topic.id !== selectedTopic) return false;
     return true;
   });
 

--- a/src/components/QuestionComponent.tsx
+++ b/src/components/QuestionComponent.tsx
@@ -16,7 +16,7 @@ const ReactMarkdown = dynamic(() => import('react-markdown'), {
 interface QuestionComponentProps {
   questionData: QuestionData;
   onNextQuestion: () => void;
-  onAnswer?: (isCorrect: boolean) => void;
+  onAnswer?: (isCorrect: boolean, questionId: string) => void;
   footerRight?: React.ReactNode;
 }
 
@@ -131,7 +131,7 @@ const QuestionComponent: React.FC<QuestionComponentProps> = ({ questionData, onN
         setExpandedOptions(new Set([correctOption.id]));
       }
       if (onAnswer) {
-        onAnswer(selectedOption.isCorrect);
+        onAnswer(selectedOption.isCorrect, questionData.id);
       }
     }
   };

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -119,6 +119,25 @@ export default function UserMenu() {
               </svg>
               <span className="text-gray-700 dark:text-gray-300">{t('stats.title')}</span>
             </button>
+            <button
+              onClick={() => { router.push('/wrong-notes'); setIsDropdownOpen(false); }}
+              className="w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex items-center gap-2"
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+                />
+              </svg>
+              <span className="text-gray-700 dark:text-gray-300">{t('wrongNotes.title')}</span>
+            </button>
             <hr className="my-2 border-gray-200 dark:border-gray-700" />
             <button
               onClick={handleLogout}

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -162,6 +162,27 @@ const en = {
     solved: 'Solved',
     correct: 'Correct',
   },
+  wrongNotes: {
+    title: 'Wrong Notes',
+    empty: 'No wrong answers yet',
+    emptyDesc: 'Take a quiz and review your mistakes',
+    reviewStart: 'Start Review',
+    reviewEmpty: 'No questions to review',
+    tabActive: 'To Review',
+    tabResolved: 'Graduated',
+    wrongCount: 'Wrong {count} times',
+    progress: '{current}/{total}',
+    graduated: 'Graduated!',
+    loginRequired: 'Log in to see your wrong notes',
+    summaryActive: '{count} to review',
+    summaryResolved: '{count} graduated',
+    topicFilter: 'Topic Filter',
+    allTopics: 'All',
+    reviewMode: 'Review Mode',
+    reviewComplete: 'Review Complete!',
+    reviewResultCorrect: '{count} correct',
+    reviewResultWrong: '{count} wrong',
+  },
 } as const;
 
 export default en;

--- a/src/lib/translations/ko.ts
+++ b/src/lib/translations/ko.ts
@@ -162,6 +162,27 @@ const ko = {
     solved: '풀이',
     correct: '정답',
   },
+  wrongNotes: {
+    title: '오답 노트',
+    empty: '아직 틀린 문제가 없어요',
+    emptyDesc: '퀴즈를 풀고 오답을 확인해보세요',
+    reviewStart: '복습 시작',
+    reviewEmpty: '복습할 문제가 없어요',
+    tabActive: '복습 대상',
+    tabResolved: '졸업한 문제',
+    wrongCount: '{count}회 틀림',
+    progress: '{current}/{total}',
+    graduated: '졸업!',
+    loginRequired: '로그인하면 오답 노트를 볼 수 있어요',
+    summaryActive: '복습할 문제 {count}개',
+    summaryResolved: '졸업한 문제 {count}개',
+    topicFilter: '토픽 필터',
+    allTopics: '전체',
+    reviewMode: '복습 모드',
+    reviewComplete: '복습 완료!',
+    reviewResultCorrect: '{count}개 맞힘',
+    reviewResultWrong: '{count}개 틀림',
+  },
 } as const;
 
 export default ko;


### PR DESCRIPTION
## 요약
틀린 문제를 자동 저장하고, 오답만 모아 복습하는 퀴즈 모드를 추가한다. 연속 3회 정답 시 "졸업" 처리되며, 졸업한 문제도 히스토리로 조회 가능. closes #36

## 변경 내용
- **스키마**: `WrongNote` 모델 추가, `QuizSession`에 `wrongQuestionIds` 필드 추가
- **퀴즈 오답 추적**: `QuestionComponent` onAnswer에 questionId 전달, 퀴즈 종료 시 WrongNote upsert
- **API 3개**: `GET /api/wrong-notes` (목록), `GET /api/wrong-notes/summary` (요약), `POST /api/wrong-notes/review-result` (졸업 처리)
- **오답 노트 페이지** (`/wrong-notes`): ACTIVE/RESOLVED 탭, 토픽 필터, 복습 시작 버튼, 졸업 프로그레스 도트
- **복습 퀴즈** (`/quiz/review`): 기존 QuestionComponent 재사용, 종료 시 세션 저장 + 졸업 처리
- **통계 연동**: `/stats`에 오답 요약 카드, UserMenu에 오답 노트 링크 추가
- **번역**: 한/영 wrongNotes 섹션 추가

## 테스트
- [ ] 일반 퀴즈에서 오답 발생 시 `/wrong-notes`에 기록되는지 확인
- [ ] 복습 퀴즈 진행 → 연속 3회 정답 시 졸업 처리 확인
- [ ] 졸업 후 일반 퀴즈에서 다시 틀리면 ACTIVE 복귀 확인
- [ ] 토픽 필터, 탭 전환 동작 확인
- [ ] `/stats` 오답 요약 카드 표시 + 클릭 시 이동 확인
- [ ] 한/영 전환 시 번역 정상 확인
- [ ] `npm run build` 통과 확인 (수동)