### PR TITLE
perf: /daily 페이지 SSR 전환 및 DB 인덱스 추가

### DIFF
--- a/prisma/migrations/20260425100550_add_performance_indexes/migration.sql
+++ b/prisma/migrations/20260425100550_add_performance_indexes/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "QuizSession" ALTER COLUMN "wrongQuestionIds" SET DEFAULT ARRAY[]::TEXT[];
+
+-- CreateIndex
+CREATE INDEX "AnswerOption_questionId_idx" ON "AnswerOption"("questionId");
+
+-- CreateIndex
+CREATE INDEX "Question_topicId_idx" ON "Question"("topicId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,8 @@ model Question {
   feedbacks     Feedback[]
   concepts      Concept[]
   wrongNotes    WrongNote[]
+
+  @@index([topicId])
 }
 
 model AnswerOption {
@@ -60,6 +62,8 @@ model AnswerOption {
   rationale_en  String
   isCorrect     Boolean
   question      Question @relation(fields: [questionId], references: [id])
+
+  @@index([questionId])
 }
 
 model User {

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -1,428 +1,97 @@
-'use client';
+import { unstable_cache } from 'next/cache';
+import prisma from '@/lib/prisma';
+import { getTodayInKST } from '@/lib/timezone';
+import DailyQuizContent from '@/components/DailyQuizContent';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import QuestionComponent from '@/components/QuestionComponent';
-import LoginModal from '@/components/LoginModal';
-import { useAuth } from '@/contexts/AuthContext';
-import { useLanguage } from '@/contexts/LanguageContext';
-import { TopicId, QuestionData } from '@/types/quizTypes';
+function getDailyQuizData() {
+  const todayKey = getTodayInKST().toISOString().slice(0, 10);
+  return unstable_cache(
+    async () => {
+      const today = getTodayInKST();
 
-interface Question {
-  id: string;
-  topicId: string;
-  topicName_ko: string;
-  topicName_en: string;
-  question_ko: string;
-  question_en: string;
-  hint_ko: string;
-  hint_en: string;
-  difficulty: QuestionData['difficulty'];
-  answerOptions: Array<{
-    id: string;
-    text_ko: string;
-    text_en: string;
-    rationale_ko: string;
-    rationale_en: string;
-    isCorrect: boolean;
-  }>;
-}
-
-export default function DailyQuizPage() {
-  const router = useRouter();
-  const { user, isLoading: authLoading } = useAuth();
-  const { t, language } = useLanguage();
-  const [questions, setQuestions] = useState<Question[]>([]);
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [dailySetId, setDailySetId] = useState('');
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [correctAnswers, setCorrectAnswers] = useState(0);
-  const [startTime] = useState(Date.now());
-  const [isCompleted, setIsCompleted] = useState(false);
-  const [score, setScore] = useState<number | null>(null);
-  const [rank, setRank] = useState<number | null>(null);
-  const [showLoginModal, setShowLoginModal] = useState(false);
-  const [scoreSubmitError, setScoreSubmitError] = useState<string | null>(null);
-  const [pendingScoreSubmit, setPendingScoreSubmit] = useState(false);
-  const [isSubmittingScore, setIsSubmittingScore] = useState(false);
-  const wrongQuestionIdsRef = useRef<string[]>([]);
-  const isTransitioning = useRef(false);
-
-  useEffect(() => {
-    async function fetchDailyQuestions() {
-      setLoading(true);
-      setError(null);
-      try {
-        const res = await fetch('/api/daily-questions');
-        if (!res.ok) {
-          throw new Error('daily.errorLoad');
-        }
-        const data = await res.json();
-        setQuestions(data.questions);
-        setDailySetId(data.dailySetId);
-      } catch (err: any) {
-        console.error(err);
-        setError(err.message);
-      } finally {
-        setLoading(false);
-      }
-    }
-    fetchDailyQuestions();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const handleAnswer = useCallback((isCorrect: boolean, questionId: string) => {
-    if (isCorrect) {
-      setCorrectAnswers(prev => prev + 1);
-    } else {
-      wrongQuestionIdsRef.current.push(questionId);
-    }
-  }, []);
-
-  const handleQuit = useCallback(async () => {
-    if (user && currentIndex > 0) {
-      const timeSpent = Math.floor((Date.now() - startTime) / 1000);
-      try {
-        await fetch('/api/quiz-session', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            quizType: 'daily',
-            dailySetId,
-            solvedCount: currentIndex,
-            correctCount: correctAnswers,
-            timeSpent,
-            wrongQuestionIds: wrongQuestionIdsRef.current,
-          }),
-        });
-      } catch {
-        // 저장 실패해도 홈으로 이동
-      }
-    }
-    router.push('/');
-  }, [user, currentIndex, correctAnswers, startTime, dailySetId, router]);
-
-  const submitScore = useCallback(async () => {
-    const timeSpent = Math.floor((Date.now() - startTime) / 1000);
-    setScoreSubmitError(null);
-    setIsSubmittingScore(true);
-
-    try {
-      fetch('/api/quiz-session', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          quizType: 'daily',
-          dailySetId,
-          solvedCount: questions.length,
-          correctCount: correctAnswers,
-          timeSpent,
-          wrongQuestionIds: wrongQuestionIdsRef.current,
-        }),
-      }).catch((err) => { console.warn('Failed to save quiz session:', err); });
-
-      const res = await fetch('/api/submit-score', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          dailySetId,
-          topicId: null,
-          correctAnswers,
-          totalQuestions: questions.length,
-          timeSpent,
-        }),
+      const dailySet = await prisma.dailyQuestionSet.findUnique({
+        where: { date: today },
       });
 
-      if (res.ok) {
-        const result = await res.json();
-        setScore(result.score);
-        setRank(result.rank);
-        setPendingScoreSubmit(false);
-      } else if (res.status === 401) {
-        const errorData = await res.json();
-        const errorMsg = errorData.error || 'daily.loginRequired';
-        setScoreSubmitError(errorMsg);
-        setPendingScoreSubmit(true);
+      if (!dailySet) {
+        return { dailySetId: null, questions: [] };
+      }
 
-        if (errorMsg.includes('User not found')) {
-          await fetch('/api/auth/logout', { method: 'POST' });
-          setShowLoginModal(true);
+      const questionIds = dailySet.questionIds;
+
+      const questions = await prisma.question.findMany({
+        where: { id: { in: questionIds } },
+        include: {
+          answerOptions: true,
+          topic: true,
+        },
+      });
+
+      const orderedQuestions = questionIds
+        .map((id: string) => questions.find((q) => q.id === id))
+        .filter((q): q is NonNullable<typeof q> => q !== undefined);
+
+      const formattedQuestions = orderedQuestions.map((question) => {
+        const options = question.answerOptions.map((option) => ({
+          id: option.id,
+          text_ko: option.text_ko,
+          text_en: option.text_en || option.text_ko,
+          rationale_ko: option.rationale_ko,
+          rationale_en: option.rationale_en || option.rationale_ko,
+          isCorrect: option.isCorrect,
+        }));
+
+        const isTrueFalse =
+          options.length === 2 &&
+          options.some((o) => /^true$/i.test(o.text_en.trim())) &&
+          options.some((o) => /^false$/i.test(o.text_en.trim()));
+
+        if (isTrueFalse) {
+          options.sort((a, b) =>
+            /^true$/i.test(a.text_en.trim()) ? -1 : 1
+          );
+        } else {
+          for (let i = options.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [options[i], options[j]] = [options[j], options[i]];
+          }
         }
-      } else {
-        setScoreSubmitError('daily.submitFailed');
-      }
-    } catch (error) {
-      console.error('Failed to submit score:', error);
-      setScoreSubmitError('daily.networkError');
-    } finally {
-      setIsSubmittingScore(false);
-    }
-  }, [startTime, dailySetId, correctAnswers, questions.length]);
 
-  useEffect(() => {
-    if (user && pendingScoreSubmit && isCompleted) {
-      submitScore();
-    }
-  }, [user, pendingScoreSubmit, isCompleted, submitScore]);
+        return {
+          id: question.id,
+          topicId: question.topicId,
+          topicName_ko: question.topic.name_ko,
+          topicName_en: question.topic.name_en || question.topic.name_ko,
+          question_ko: question.text_ko,
+          question_en: question.text_en || question.text_ko,
+          hint_ko: question.hint_ko,
+          hint_en: question.hint_en || question.hint_ko,
+          difficulty: question.difficulty,
+          answerOptions: options,
+        };
+      });
 
-  const handleNextQuestion = useCallback(async () => {
-    if (isTransitioning.current) return;
-    isTransitioning.current = true;
+      return {
+        dailySetId: dailySet.id,
+        questions: formattedQuestions,
+      };
+    },
+    [`daily-questions-${todayKey}`],
+    { revalidate: 3600 }
+  )();
+}
 
-    if (currentIndex < questions.length - 1) {
-      setCurrentIndex(prev => prev + 1);
-    } else {
-      setIsCompleted(true);
-      if (user) {
-        await submitScore();
-      } else {
-        setPendingScoreSubmit(true);
-      }
-    }
+export default async function DailyQuizPage() {
+  let dailySetId: string | null = null;
+  let questions: any[] = [];
 
-    // 다음 문제 렌더링 후 가드 해제
-    requestAnimationFrame(() => { isTransitioning.current = false; });
-  }, [currentIndex, questions.length, user, submitScore]);
-
-  const handleLoginSuccess = () => {
-    setShowLoginModal(false);
-  };
-
-  if (loading || authLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <p className="text-xl text-gray-600 animate-pulse">{t('daily.loading')}</p>
-      </div>
-    );
+  try {
+    const data = await getDailyQuizData();
+    dailySetId = data.dailySetId;
+    questions = data.questions;
+  } catch (error) {
+    console.error('Failed to fetch daily quiz data:', error);
   }
 
-  if (error) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <p className="text-xl text-red-600 mb-4">{t('common.error')}: {t(error) !== error ? t(error) : error}</p>
-          <div className="flex gap-3 justify-center">
-            <button
-              onClick={() => {
-                setError(null);
-                setLoading(true);
-                fetch('/api/daily-questions')
-                  .then(res => {
-                    if (!res.ok) throw new Error('Failed to load');
-                    return res.json();
-                  })
-                  .then(data => {
-                    setQuestions(data.questions);
-                    setDailySetId(data.dailySetId);
-                  })
-                  .catch(err => setError(err.message))
-                  .finally(() => setLoading(false));
-              }}
-              className="px-6 py-3 bg-gradient-to-r from-orange-500 to-amber-500 text-white rounded-lg hover:from-orange-600 hover:to-amber-600 transition-all font-semibold shadow-md hover:shadow-lg"
-            >
-              {t('common.retry')}
-            </button>
-            <button
-              onClick={() => router.push('/')}
-              className="px-6 py-3 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors font-semibold"
-            >
-              {t('common.goHome')}
-            </button>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  if (isCompleted) {
-    return (
-      <>
-        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-orange-50 via-amber-50 to-gray-50 py-8">
-          <div className="text-center bg-white p-8 rounded-2xl shadow-2xl max-w-md w-full mx-4 border-2 border-orange-100">
-            <div className="inline-flex items-center justify-center w-20 h-20 bg-gradient-to-br from-orange-400 to-amber-500 rounded-2xl mb-6 shadow-lg">
-              <svg className="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-            </div>
-            <h2 className="text-3xl font-bold mb-6 text-gray-900">
-              {t('daily.complete')}
-            </h2>
-
-            <div className="space-y-4 mb-6">
-              {/* 정답률 */}
-              <div className="p-5 bg-gradient-to-br from-orange-50 to-amber-50 border border-orange-200 rounded-xl">
-                <p className="text-orange-700 text-sm font-semibold">{t('common.correct')}</p>
-                <p className="text-4xl font-bold text-orange-600">
-                  {correctAnswers} / {questions.length}
-                </p>
-              </div>
-
-              {/* 점수 */}
-              {isSubmittingScore && score === null ? (
-                <div className="p-5 bg-gradient-to-br from-gray-50 to-slate-50 border border-gray-200 rounded-xl animate-pulse">
-                  <div className="h-4 w-12 bg-gray-200 rounded mb-2"></div>
-                  <div className="h-10 w-24 bg-gray-200 rounded"></div>
-                </div>
-              ) : score !== null ? (
-                <div className="p-5 bg-gradient-to-br from-gray-50 to-slate-50 border border-gray-200 rounded-xl">
-                  <p className="text-gray-700 text-sm font-semibold">{t('common.score')}</p>
-                  <p className="text-4xl font-bold text-gray-800">{score}</p>
-                </div>
-              ) : null}
-
-              {/* 순위 */}
-              {isSubmittingScore && rank === null ? (
-                <div className="p-5 bg-gradient-to-br from-green-50 to-emerald-50 border border-green-200 rounded-xl animate-pulse">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <div className="h-4 w-12 bg-green-200 rounded mb-2"></div>
-                      <div className="h-10 w-20 bg-green-200 rounded"></div>
-                    </div>
-                    <div className="w-12 h-12 bg-green-200 rounded-xl"></div>
-                  </div>
-                </div>
-              ) : rank !== null ? (
-                <div className="p-5 bg-gradient-to-br from-green-50 to-emerald-50 border border-green-200 rounded-xl">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <p className="text-green-700 text-sm font-semibold">{t('common.rank')}</p>
-                      <p className="text-4xl font-bold text-green-600">#{rank}</p>
-                    </div>
-                    <div className="w-12 h-12 bg-gradient-to-br from-green-400 to-emerald-500 rounded-xl flex items-center justify-center shadow-md">
-                      <svg className="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
-                      </svg>
-                    </div>
-                  </div>
-                </div>
-              ) : null}
-
-              {/* 비로그인 사용자 안내 */}
-              {!user && !isSubmittingScore && (
-                <div className="p-5 bg-gradient-to-br from-amber-50 to-yellow-50 border-2 border-amber-300 rounded-xl">
-                  <div className="flex items-start gap-3 mb-3">
-                    <div className="w-10 h-10 bg-gradient-to-br from-amber-400 to-yellow-500 rounded-lg flex items-center justify-center flex-shrink-0 shadow-md">
-                      <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
-                      </svg>
-                    </div>
-                    <div className="flex-1">
-                      <p className="text-amber-900 font-bold mb-1">{t('daily.niceResult')}</p>
-                      <p className="text-sm text-amber-800">
-                        {t('daily.registerLeaderboard')}
-                      </p>
-                    </div>
-                  </div>
-                  <button
-                    onClick={() => setShowLoginModal(true)}
-                    className="w-full py-3 bg-gradient-to-r from-orange-500 to-amber-500 text-white rounded-lg font-semibold hover:from-orange-600 hover:to-amber-600 transition-all shadow-md hover:shadow-lg"
-                  >
-                    {t('daily.register')}
-                  </button>
-                </div>
-              )}
-
-              {/* 에러 메시지 */}
-              {scoreSubmitError && user && !isSubmittingScore && (
-                <div className="p-4 bg-red-50 border border-red-200 rounded-lg">
-                  <p className="text-sm text-red-700">{t(scoreSubmitError) !== scoreSubmitError ? t(scoreSubmitError) : scoreSubmitError}</p>
-                </div>
-              )}
-            </div>
-
-            {/* 버튼 */}
-            <div className="flex gap-3">
-              {user && score !== null ? (
-                <button
-                  onClick={() => router.push('/leaderboard?dailySetId=' + dailySetId)}
-                  disabled={isSubmittingScore}
-                  className="flex-1 px-4 py-3 bg-gradient-to-r from-orange-500 to-amber-500 text-white rounded-xl hover:from-orange-600 hover:to-amber-600 transition-all font-bold shadow-md hover:shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {t('daily.viewLeaderboard')}
-                </button>
-              ) : null}
-              <button
-                onClick={() => router.push('/')}
-                disabled={isSubmittingScore}
-                className="flex-1 px-4 py-3 bg-gray-200 text-gray-700 rounded-xl hover:bg-gray-300 transition-colors font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {t('common.homeShort')}
-              </button>
-            </div>
-          </div>
-        </div>
-
-        {/* 로그인 모달 */}
-        <LoginModal
-          isOpen={showLoginModal}
-          onClose={() => setShowLoginModal(false)}
-          onSuccess={handleLoginSuccess}
-          message={t('daily.loginForLeaderboard')}
-        />
-      </>
-    );
-  }
-
-  const currentQuestion = questions[currentIndex];
-
-  return (
-    <main className="container mx-auto px-4 py-8">
-      <div className="max-w-3xl mx-auto">
-        <div className="flex justify-between items-center mb-8">
-          <div>
-            <h1 className="text-3xl font-bold text-gray-900 flex items-center gap-3">
-              <div className="w-10 h-10 bg-gradient-to-br from-orange-400 to-amber-500 rounded-2xl flex items-center justify-center shadow-lg">
-                <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                </svg>
-              </div>
-              {t('daily.title')}
-            </h1>
-            <p className="text-gray-600 mt-2">
-              {currentIndex + 1} / {questions.length}
-            </p>
-          </div>
-          <button
-            onClick={handleQuit}
-            className="px-4 py-2 text-gray-600 hover:text-gray-800 transition-colors font-medium"
-          >
-            {t('daily.quit')}
-          </button>
-        </div>
-
-        {/* 진행률 바 */}
-        <div className="mb-6 bg-gray-100 rounded-full h-2.5 shadow-inner">
-          <div
-            className="bg-gradient-to-r from-orange-500 to-amber-500 h-2.5 rounded-full transition-all duration-500 shadow-sm"
-            style={{ width: `${((currentIndex + 1) / questions.length) * 100}%` }}
-          />
-        </div>
-
-        {currentQuestion && (
-          <div>
-            <div className="mb-4 px-4 py-2 bg-gradient-to-r from-orange-100 to-amber-100 text-orange-800 rounded-full inline-flex items-center gap-2 text-sm font-semibold border border-orange-200">
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
-              </svg>
-              {language === 'en' ? currentQuestion.topicName_en : currentQuestion.topicName_ko}
-            </div>
-            <QuestionComponent
-              questionData={{
-                id: currentQuestion.id,
-                topicId: currentQuestion.topicId as TopicId,
-                question_ko: currentQuestion.question_ko,
-                question_en: currentQuestion.question_en,
-                hint_ko: currentQuestion.hint_ko,
-                hint_en: currentQuestion.hint_en,
-                difficulty: currentQuestion.difficulty,
-                answerOptions: currentQuestion.answerOptions,
-              }}
-              onNextQuestion={handleNextQuestion}
-              onAnswer={handleAnswer}
-            />
-          </div>
-        )}
-      </div>
-    </main>
-  );
+  return <DailyQuizContent questions={questions} dailySetId={dailySetId} />;
 }

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -77,7 +77,7 @@ function getDailyQuizData() {
       };
     },
     [`daily-questions-${todayKey}`],
-    { revalidate: 3600 }
+    { revalidate: 43200 }
   )();
 }
 

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -1,13 +1,13 @@
 import { unstable_cache } from 'next/cache';
 import prisma from '@/lib/prisma';
 import { getTodayInKST } from '@/lib/timezone';
-import DailyQuizContent from '@/components/DailyQuizContent';
+import DailyQuizContent, { DailyQuestion } from '@/components/DailyQuizContent';
 
 function getDailyQuizData() {
-  const todayKey = getTodayInKST().toISOString().slice(0, 10);
+  const today = getTodayInKST();
+  const todayKey = today.toISOString().slice(0, 10);
   return unstable_cache(
     async () => {
-      const today = getTodayInKST();
 
       const dailySet = await prisma.dailyQuestionSet.findUnique({
         where: { date: today },
@@ -83,7 +83,7 @@ function getDailyQuizData() {
 
 export default async function DailyQuizPage() {
   let dailySetId: string | null = null;
-  let questions: any[] = [];
+  let questions: DailyQuestion[] = [];
 
   try {
     const data = await getDailyQuizData();

--- a/src/components/DailyQuizContent.tsx
+++ b/src/components/DailyQuizContent.tsx
@@ -1,0 +1,377 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import QuestionComponent from '@/components/QuestionComponent';
+import LoginModal from '@/components/LoginModal';
+import { useAuth } from '@/contexts/AuthContext';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { TopicId, QuestionData } from '@/types/quizTypes';
+
+export interface DailyQuestion {
+  id: string;
+  topicId: string;
+  topicName_ko: string;
+  topicName_en: string;
+  question_ko: string;
+  question_en: string;
+  hint_ko: string;
+  hint_en: string;
+  difficulty: QuestionData['difficulty'];
+  answerOptions: Array<{
+    id: string;
+    text_ko: string;
+    text_en: string;
+    rationale_ko: string;
+    rationale_en: string;
+    isCorrect: boolean;
+  }>;
+}
+
+interface DailyQuizContentProps {
+  questions: DailyQuestion[];
+  dailySetId: string | null;
+}
+
+export default function DailyQuizContent({ questions, dailySetId }: DailyQuizContentProps) {
+  const router = useRouter();
+  const { user } = useAuth();
+  const { t, language } = useLanguage();
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [correctAnswers, setCorrectAnswers] = useState(0);
+  const [startTime] = useState(Date.now());
+  const [isCompleted, setIsCompleted] = useState(false);
+  const [score, setScore] = useState<number | null>(null);
+  const [rank, setRank] = useState<number | null>(null);
+  const [showLoginModal, setShowLoginModal] = useState(false);
+  const [scoreSubmitError, setScoreSubmitError] = useState<string | null>(null);
+  const [pendingScoreSubmit, setPendingScoreSubmit] = useState(false);
+  const [isSubmittingScore, setIsSubmittingScore] = useState(false);
+  const wrongQuestionIdsRef = useRef<string[]>([]);
+  const isTransitioning = useRef(false);
+
+  const handleAnswer = useCallback((isCorrect: boolean, questionId: string) => {
+    if (isCorrect) {
+      setCorrectAnswers(prev => prev + 1);
+    } else {
+      wrongQuestionIdsRef.current.push(questionId);
+    }
+  }, []);
+
+  const handleQuit = useCallback(async () => {
+    if (user && currentIndex > 0) {
+      const timeSpent = Math.floor((Date.now() - startTime) / 1000);
+      try {
+        await fetch('/api/quiz-session', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            quizType: 'daily',
+            dailySetId,
+            solvedCount: currentIndex,
+            correctCount: correctAnswers,
+            timeSpent,
+            wrongQuestionIds: wrongQuestionIdsRef.current,
+          }),
+        });
+      } catch {
+        // 저장 실패해도 홈으로 이동
+      }
+    }
+    router.push('/');
+  }, [user, currentIndex, correctAnswers, startTime, dailySetId, router]);
+
+  const submitScore = useCallback(async () => {
+    const timeSpent = Math.floor((Date.now() - startTime) / 1000);
+    setScoreSubmitError(null);
+    setIsSubmittingScore(true);
+
+    try {
+      fetch('/api/quiz-session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          quizType: 'daily',
+          dailySetId,
+          solvedCount: questions.length,
+          correctCount: correctAnswers,
+          timeSpent,
+          wrongQuestionIds: wrongQuestionIdsRef.current,
+        }),
+      }).catch((err) => { console.warn('Failed to save quiz session:', err); });
+
+      const res = await fetch('/api/submit-score', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          dailySetId,
+          topicId: null,
+          correctAnswers,
+          totalQuestions: questions.length,
+          timeSpent,
+        }),
+      });
+
+      if (res.ok) {
+        const result = await res.json();
+        setScore(result.score);
+        setRank(result.rank);
+        setPendingScoreSubmit(false);
+      } else if (res.status === 401) {
+        const errorData = await res.json();
+        const errorMsg = errorData.error || 'daily.loginRequired';
+        setScoreSubmitError(errorMsg);
+        setPendingScoreSubmit(true);
+
+        if (errorMsg.includes('User not found')) {
+          await fetch('/api/auth/logout', { method: 'POST' });
+          setShowLoginModal(true);
+        }
+      } else {
+        setScoreSubmitError('daily.submitFailed');
+      }
+    } catch (error) {
+      console.error('Failed to submit score:', error);
+      setScoreSubmitError('daily.networkError');
+    } finally {
+      setIsSubmittingScore(false);
+    }
+  }, [startTime, dailySetId, correctAnswers, questions.length]);
+
+  useEffect(() => {
+    if (user && pendingScoreSubmit && isCompleted) {
+      submitScore();
+    }
+  }, [user, pendingScoreSubmit, isCompleted, submitScore]);
+
+  const handleNextQuestion = useCallback(async () => {
+    if (isTransitioning.current) return;
+    isTransitioning.current = true;
+
+    if (currentIndex < questions.length - 1) {
+      setCurrentIndex(prev => prev + 1);
+    } else {
+      setIsCompleted(true);
+      if (user) {
+        await submitScore();
+      } else {
+        setPendingScoreSubmit(true);
+      }
+    }
+
+    // 다음 문제 렌더링 후 가드 해제
+    requestAnimationFrame(() => { isTransitioning.current = false; });
+  }, [currentIndex, questions.length, user, submitScore]);
+
+  const handleLoginSuccess = () => {
+    setShowLoginModal(false);
+  };
+
+  if (!dailySetId || questions.length === 0) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-xl text-gray-600 dark:text-gray-400 mb-4">{t('daily.errorLoad')}</p>
+          <button
+            onClick={() => router.push('/')}
+            className="px-6 py-3 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors font-semibold"
+          >
+            {t('common.goHome')}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (isCompleted) {
+    return (
+      <>
+        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-orange-50 via-amber-50 to-gray-50 py-8">
+          <div className="text-center bg-white p-8 rounded-2xl shadow-2xl max-w-md w-full mx-4 border-2 border-orange-100">
+            <div className="inline-flex items-center justify-center w-20 h-20 bg-gradient-to-br from-orange-400 to-amber-500 rounded-2xl mb-6 shadow-lg">
+              <svg className="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </div>
+            <h2 className="text-3xl font-bold mb-6 text-gray-900">
+              {t('daily.complete')}
+            </h2>
+
+            <div className="space-y-4 mb-6">
+              {/* 정답률 */}
+              <div className="p-5 bg-gradient-to-br from-orange-50 to-amber-50 border border-orange-200 rounded-xl">
+                <p className="text-orange-700 text-sm font-semibold">{t('common.correct')}</p>
+                <p className="text-4xl font-bold text-orange-600">
+                  {correctAnswers} / {questions.length}
+                </p>
+              </div>
+
+              {/* 점수 */}
+              {isSubmittingScore && score === null ? (
+                <div className="p-5 bg-gradient-to-br from-gray-50 to-slate-50 border border-gray-200 rounded-xl animate-pulse">
+                  <div className="h-4 w-12 bg-gray-200 rounded mb-2"></div>
+                  <div className="h-10 w-24 bg-gray-200 rounded"></div>
+                </div>
+              ) : score !== null ? (
+                <div className="p-5 bg-gradient-to-br from-gray-50 to-slate-50 border border-gray-200 rounded-xl">
+                  <p className="text-gray-700 text-sm font-semibold">{t('common.score')}</p>
+                  <p className="text-4xl font-bold text-gray-800">{score}</p>
+                </div>
+              ) : null}
+
+              {/* 순위 */}
+              {isSubmittingScore && rank === null ? (
+                <div className="p-5 bg-gradient-to-br from-green-50 to-emerald-50 border border-green-200 rounded-xl animate-pulse">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <div className="h-4 w-12 bg-green-200 rounded mb-2"></div>
+                      <div className="h-10 w-20 bg-green-200 rounded"></div>
+                    </div>
+                    <div className="w-12 h-12 bg-green-200 rounded-xl"></div>
+                  </div>
+                </div>
+              ) : rank !== null ? (
+                <div className="p-5 bg-gradient-to-br from-green-50 to-emerald-50 border border-green-200 rounded-xl">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-green-700 text-sm font-semibold">{t('common.rank')}</p>
+                      <p className="text-4xl font-bold text-green-600">#{rank}</p>
+                    </div>
+                    <div className="w-12 h-12 bg-gradient-to-br from-green-400 to-emerald-500 rounded-xl flex items-center justify-center shadow-md">
+                      <svg className="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+
+              {/* 비로그인 사용자 안내 */}
+              {!user && !isSubmittingScore && (
+                <div className="p-5 bg-gradient-to-br from-amber-50 to-yellow-50 border-2 border-amber-300 rounded-xl">
+                  <div className="flex items-start gap-3 mb-3">
+                    <div className="w-10 h-10 bg-gradient-to-br from-amber-400 to-yellow-500 rounded-lg flex items-center justify-center flex-shrink-0 shadow-md">
+                      <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+                      </svg>
+                    </div>
+                    <div className="flex-1">
+                      <p className="text-amber-900 font-bold mb-1">{t('daily.niceResult')}</p>
+                      <p className="text-sm text-amber-800">
+                        {t('daily.registerLeaderboard')}
+                      </p>
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => setShowLoginModal(true)}
+                    className="w-full py-3 bg-gradient-to-r from-orange-500 to-amber-500 text-white rounded-lg font-semibold hover:from-orange-600 hover:to-amber-600 transition-all shadow-md hover:shadow-lg"
+                  >
+                    {t('daily.register')}
+                  </button>
+                </div>
+              )}
+
+              {/* 에러 메시지 */}
+              {scoreSubmitError && user && !isSubmittingScore && (
+                <div className="p-4 bg-red-50 border border-red-200 rounded-lg">
+                  <p className="text-sm text-red-700">{t(scoreSubmitError) !== scoreSubmitError ? t(scoreSubmitError) : scoreSubmitError}</p>
+                </div>
+              )}
+            </div>
+
+            {/* 버튼 */}
+            <div className="flex gap-3">
+              {user && score !== null ? (
+                <button
+                  onClick={() => router.push('/leaderboard?dailySetId=' + dailySetId)}
+                  disabled={isSubmittingScore}
+                  className="flex-1 px-4 py-3 bg-gradient-to-r from-orange-500 to-amber-500 text-white rounded-xl hover:from-orange-600 hover:to-amber-600 transition-all font-bold shadow-md hover:shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {t('daily.viewLeaderboard')}
+                </button>
+              ) : null}
+              <button
+                onClick={() => router.push('/')}
+                disabled={isSubmittingScore}
+                className="flex-1 px-4 py-3 bg-gray-200 text-gray-700 rounded-xl hover:bg-gray-300 transition-colors font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {t('common.homeShort')}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* 로그인 모달 */}
+        <LoginModal
+          isOpen={showLoginModal}
+          onClose={() => setShowLoginModal(false)}
+          onSuccess={handleLoginSuccess}
+          message={t('daily.loginForLeaderboard')}
+        />
+      </>
+    );
+  }
+
+  const currentQuestion = questions[currentIndex];
+
+  return (
+    <main className="container mx-auto px-4 py-8">
+      <div className="max-w-3xl mx-auto">
+        <div className="flex justify-between items-center mb-8">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900 flex items-center gap-3">
+              <div className="w-10 h-10 bg-gradient-to-br from-orange-400 to-amber-500 rounded-2xl flex items-center justify-center shadow-lg">
+                <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+              </div>
+              {t('daily.title')}
+            </h1>
+            <p className="text-gray-600 mt-2">
+              {currentIndex + 1} / {questions.length}
+            </p>
+          </div>
+          <button
+            onClick={handleQuit}
+            className="px-4 py-2 text-gray-600 hover:text-gray-800 transition-colors font-medium"
+          >
+            {t('daily.quit')}
+          </button>
+        </div>
+
+        {/* 진행률 바 */}
+        <div className="mb-6 bg-gray-100 rounded-full h-2.5 shadow-inner">
+          <div
+            className="bg-gradient-to-r from-orange-500 to-amber-500 h-2.5 rounded-full transition-all duration-500 shadow-sm"
+            style={{ width: `${((currentIndex + 1) / questions.length) * 100}%` }}
+          />
+        </div>
+
+        {currentQuestion && (
+          <div>
+            <div className="mb-4 px-4 py-2 bg-gradient-to-r from-orange-100 to-amber-100 text-orange-800 rounded-full inline-flex items-center gap-2 text-sm font-semibold border border-orange-200">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+              </svg>
+              {language === 'en' ? currentQuestion.topicName_en : currentQuestion.topicName_ko}
+            </div>
+            <QuestionComponent
+              questionData={{
+                id: currentQuestion.id,
+                topicId: currentQuestion.topicId as TopicId,
+                question_ko: currentQuestion.question_ko,
+                question_en: currentQuestion.question_en,
+                hint_ko: currentQuestion.hint_ko,
+                hint_en: currentQuestion.hint_en,
+                difficulty: currentQuestion.difficulty,
+                answerOptions: currentQuestion.answerOptions,
+              }}
+              onNextQuestion={handleNextQuestion}
+              onAnswer={handleAnswer}
+            />
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## 요약
- Vercel + Neon 프리티어 환경에서 `/daily` 페이지 로딩이 느린 문제 해결. 클라이언트 fetch 워터폴을 제거하고 DB 쿼리 성능을 개선한다.

## 변경 내용
- `prisma/schema.prisma`: `Question.topicId`, `AnswerOption.questionId`에 `@@index` 추가
- `src/components/DailyQuizContent.tsx`: 기존 `/daily` 페이지의 클라이언트 로직을 별도 컴포넌트로 추출
- `src/app/daily/page.tsx`: Client Component → Server Component 전환, `unstable_cache`로 1시간 캐싱 적용

## 테스트
- [x] `npm run check` (lint + type-check) 통과
- [x] `npm run build` 성공 — `/daily` 라우트가 `○ (Static/ISR)`로 변경됨 확인
- [ ] Vercel 배포 후 `/daily` 로딩 속도 체감 확인 (수동)