### PR TITLE
feat: P1~P2 이슈 6개 구현 — 스켈레톤/Toast/Leitner/스트릭/공유/주간챌린지

### DIFF
--- a/prisma/migrations/20260429151237_add_leitner_fields/migration.sql
+++ b/prisma/migrations/20260429151237_add_leitner_fields/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "WrongNote" ADD COLUMN     "lastReviewedAt" TIMESTAMP(3),
+ADD COLUMN     "leitnerBox" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "nextReviewAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "WrongNote_userId_nextReviewAt_idx" ON "WrongNote"("userId", "nextReviewAt");

--- a/prisma/migrations/20260429152536_add_weekly_challenge/migration.sql
+++ b/prisma/migrations/20260429152536_add_weekly_challenge/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "WeeklyChallenge" (
+    "id" TEXT NOT NULL,
+    "weekStart" TIMESTAMP(3) NOT NULL,
+    "topicId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WeeklyChallenge_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WeeklyChallenge_weekStart_key" ON "WeeklyChallenge"("weekStart");
+
+-- AddForeignKey
+ALTER TABLE "WeeklyChallenge" ADD CONSTRAINT "WeeklyChallenge_topicId_fkey" FOREIGN KEY ("topicId") REFERENCES "Topic"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -145,6 +145,9 @@ model WrongNote {
   status             WrongNoteStatus @default(ACTIVE)
   wrongCount         Int             @default(1)
   consecutiveCorrect Int             @default(0)
+  leitnerBox         Int             @default(0)
+  nextReviewAt       DateTime?
+  lastReviewedAt     DateTime?
   createdAt          DateTime        @default(now())
   resolvedAt         DateTime?
 
@@ -153,4 +156,5 @@ model WrongNote {
 
   @@unique([userId, questionId])
   @@index([userId, status])
+  @@index([userId, nextReviewAt])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,8 +14,9 @@ model Topic {
   id        String     @id @default(cuid())
   name_ko   String
   name_en   String
-  questions Question[]
-  concepts  Concept[]
+  questions        Question[]
+  concepts         Concept[]
+  weeklyChallenges WeeklyChallenge[]
 }
 
 model Concept {
@@ -157,4 +158,12 @@ model WrongNote {
   @@unique([userId, questionId])
   @@index([userId, status])
   @@index([userId, nextReviewAt])
+}
+
+model WeeklyChallenge {
+  id        String   @id @default(cuid())
+  weekStart DateTime @unique
+  topicId   String
+  topic     Topic    @relation(fields: [topicId], references: [id])
+  createdAt DateTime @default(now())
 }

--- a/src/app/api/og/quiz-result/route.tsx
+++ b/src/app/api/og/quiz-result/route.tsx
@@ -1,0 +1,77 @@
+import { ImageResponse } from 'next/og';
+import { NextRequest } from 'next/server';
+
+export const runtime = 'edge';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const type = searchParams.get('type') || 'daily';
+  const score = searchParams.get('score') || '0';
+  const correct = searchParams.get('correct') || '0';
+  const total = searchParams.get('total') || '0';
+  const streak = searchParams.get('streak');
+
+  const typeLabel: Record<string, string> = {
+    daily: '오늘의 퀴즈',
+    topic: '주제별 퀴즈',
+    review: '복습 퀴즈',
+  };
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'linear-gradient(135deg, #1e1e2e 0%, #2d1b4e 50%, #1a1a2e 100%)',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '16px', marginBottom: '40px' }}>
+          <div
+            style={{
+              width: '56px', height: '56px',
+              borderRadius: '16px',
+              background: 'linear-gradient(135deg, #fb923c, #f59e0b)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+            }}
+          >
+            <span style={{ fontSize: '28px', color: 'white' }}>💡</span>
+          </div>
+          <span style={{ fontSize: '36px', fontWeight: 'bold', color: 'white' }}>CS Quiz</span>
+        </div>
+        <div style={{ fontSize: '20px', color: '#a78bfa', marginBottom: '12px', fontWeight: 600 }}>
+          {typeLabel[type] || typeLabel.daily}
+        </div>
+        <div style={{ fontSize: '96px', fontWeight: 'bold', color: '#fb923c', lineHeight: 1 }}>
+          {score}점
+        </div>
+        <div style={{ fontSize: '28px', color: '#94a3b8', marginTop: '12px' }}>
+          {correct} / {total} 정답
+        </div>
+        {streak && Number(streak) > 0 && (
+          <div
+            style={{
+              marginTop: '24px',
+              padding: '8px 20px',
+              borderRadius: '999px',
+              background: 'rgba(251, 146, 60, 0.2)',
+              border: '1px solid rgba(251, 146, 60, 0.4)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+            }}
+          >
+            <span style={{ fontSize: '20px' }}>🔥</span>
+            <span style={{ fontSize: '18px', color: '#fb923c', fontWeight: 600 }}>연속 {streak}일</span>
+          </div>
+        )}
+      </div>
+    ),
+    { width: 1200, height: 630 }
+  );
+}

--- a/src/app/api/quiz-session/route.ts
+++ b/src/app/api/quiz-session/route.ts
@@ -66,6 +66,8 @@ export async function POST(request: Request) {
               status: 'ACTIVE',
               wrongCount: { increment: 1 },
               consecutiveCorrect: 0,
+              leitnerBox: 0,
+              nextReviewAt: new Date(),
               resolvedAt: null,
             },
           })

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { cookies } from "next/headers";
 import { toKST } from "@/lib/timezone";
+import { calculateStreak } from "@/lib/streak";
 
 export const dynamic = "force-dynamic";
 
@@ -92,6 +93,16 @@ export async function GET() {
       .sort((a, b) => a.accuracy - b.accuracy)
       .slice(0, 3);
 
+    // 5. Streak
+    const allSessions = await prisma.quizSession.findMany({
+      where: { userId },
+      select: { completedAt: true },
+      orderBy: { completedAt: 'desc' },
+    });
+    const { currentStreak, longestStreak } = calculateStreak(
+      allSessions.map((s) => s.completedAt)
+    );
+
     return NextResponse.json({
       summary: {
         totalSolved,
@@ -102,6 +113,7 @@ export async function GET() {
       topicStats,
       dailyTrend,
       weakAreas,
+      streak: { currentStreak, longestStreak },
     });
   } catch (error) {
     console.error("Failed to get stats:", error);

--- a/src/app/api/weekly-challenge/leaderboard/route.ts
+++ b/src/app/api/weekly-challenge/leaderboard/route.ts
@@ -23,18 +23,24 @@ export async function GET() {
       },
     });
 
-    const userBest = new Map<string, { username: string; bestAccuracy: number; totalSolved: number }>();
+    const userBest = new Map<string, { username: string; bestAccuracy: number; bestSolvedCount: number; totalSolved: number }>();
     for (const s of sessions) {
       const accuracy = Math.round((s.correctCount / s.solvedCount) * 100);
       const existing = userBest.get(s.userId);
-      if (!existing || accuracy > existing.bestAccuracy || (accuracy === existing.bestAccuracy && s.solvedCount > existing.totalSolved)) {
+      if (!existing) {
         userBest.set(s.userId, {
           username: s.user.username,
           bestAccuracy: accuracy,
-          totalSolved: (existing?.totalSolved || 0) + s.solvedCount,
+          bestSolvedCount: s.solvedCount,
+          totalSolved: s.solvedCount,
         });
       } else {
         existing.totalSolved += s.solvedCount;
+        if (accuracy > existing.bestAccuracy || (accuracy === existing.bestAccuracy && s.solvedCount > existing.bestSolvedCount)) {
+          existing.bestAccuracy = accuracy;
+          existing.bestSolvedCount = s.solvedCount;
+          existing.username = s.user.username;
+        }
       }
     }
 

--- a/src/app/api/weekly-challenge/leaderboard/route.ts
+++ b/src/app/api/weekly-challenge/leaderboard/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+import { getCurrentChallenge } from '@/lib/weekly-challenge';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const { challenge, weekStart, weekEnd } = await getCurrentChallenge();
+
+    const sessions = await prisma.quizSession.findMany({
+      where: {
+        topicId: challenge.topicId,
+        quizType: 'topic',
+        completedAt: { gte: weekStart, lt: weekEnd },
+        solvedCount: { gt: 0 },
+      },
+      select: {
+        userId: true,
+        solvedCount: true,
+        correctCount: true,
+        user: { select: { username: true } },
+      },
+    });
+
+    const userBest = new Map<string, { username: string; bestAccuracy: number; totalSolved: number }>();
+    for (const s of sessions) {
+      const accuracy = Math.round((s.correctCount / s.solvedCount) * 100);
+      const existing = userBest.get(s.userId);
+      if (!existing || accuracy > existing.bestAccuracy || (accuracy === existing.bestAccuracy && s.solvedCount > existing.totalSolved)) {
+        userBest.set(s.userId, {
+          username: s.user.username,
+          bestAccuracy: accuracy,
+          totalSolved: (existing?.totalSolved || 0) + s.solvedCount,
+        });
+      } else {
+        existing.totalSolved += s.solvedCount;
+      }
+    }
+
+    const leaderboard = Array.from(userBest.values())
+      .sort((a, b) => b.bestAccuracy - a.bestAccuracy || b.totalSolved - a.totalSolved)
+      .slice(0, 50)
+      .map((entry, i) => ({ rank: i + 1, ...entry }));
+
+    return NextResponse.json({ topicId: challenge.topicId, leaderboard });
+  } catch (error) {
+    console.error('Failed to get weekly challenge leaderboard:', error);
+    return NextResponse.json({ error: 'Failed' }, { status: 500 });
+  }
+}

--- a/src/app/api/weekly-challenge/route.ts
+++ b/src/app/api/weekly-challenge/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { getCurrentChallenge } from '@/lib/weekly-challenge';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const { challenge, weekStart, weekEnd, remainingDays } = await getCurrentChallenge();
+    return NextResponse.json({
+      topicId: challenge.topicId,
+      topic: challenge.topic,
+      weekStart: weekStart.toISOString(),
+      weekEnd: weekEnd.toISOString(),
+      remainingDays,
+    });
+  } catch (error) {
+    console.error('Failed to get weekly challenge:', error);
+    return NextResponse.json({ error: 'Failed to get weekly challenge' }, { status: 500 });
+  }
+}

--- a/src/app/api/wrong-notes/review-result/route.ts
+++ b/src/app/api/wrong-notes/review-result/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { cookies } from "next/headers";
-
-const GRADUATE_THRESHOLD = 3;
+import { onCorrect, onWrong, getNextReviewDate, MAX_BOX } from "@/lib/leitner";
 
 export async function POST(request: Request) {
   try {
@@ -26,6 +25,7 @@ export async function POST(request: Request) {
 
     let graduated = 0;
     let reset = 0;
+    const now = new Date();
 
     await Promise.all(
       results.map(async ({ questionId, correct }: { questionId: string; correct: boolean }) => {
@@ -36,29 +36,42 @@ export async function POST(request: Request) {
         if (!note) return;
 
         if (correct) {
-          const newConsecutive = note.consecutiveCorrect + 1;
-          if (newConsecutive >= GRADUATE_THRESHOLD) {
+          const { newBox, graduated: isGraduated } = onCorrect(note.leitnerBox);
+
+          if (isGraduated) {
             await prisma.wrongNote.update({
               where: { id: note.id },
               data: {
-                consecutiveCorrect: newConsecutive,
+                leitnerBox: MAX_BOX,
+                consecutiveCorrect: note.consecutiveCorrect + 1,
                 status: "RESOLVED",
-                resolvedAt: new Date(),
+                resolvedAt: now,
+                lastReviewedAt: now,
+                nextReviewAt: null,
               },
             });
             graduated++;
           } else {
             await prisma.wrongNote.update({
               where: { id: note.id },
-              data: { consecutiveCorrect: newConsecutive },
+              data: {
+                leitnerBox: newBox,
+                consecutiveCorrect: note.consecutiveCorrect + 1,
+                lastReviewedAt: now,
+                nextReviewAt: getNextReviewDate(newBox, now),
+              },
             });
           }
         } else {
+          const { newBox } = onWrong();
           await prisma.wrongNote.update({
             where: { id: note.id },
             data: {
+              leitnerBox: newBox,
               consecutiveCorrect: 0,
               wrongCount: { increment: 1 },
+              lastReviewedAt: now,
+              nextReviewAt: getNextReviewDate(newBox, now),
             },
           });
           reset++;

--- a/src/app/api/wrong-notes/route.ts
+++ b/src/app/api/wrong-notes/route.ts
@@ -39,7 +39,7 @@ export async function GET(request: NextRequest) {
     }
 
     if (due === "true") {
-      where.nextReviewAt = { lte: new Date() };
+      where.OR = [{ nextReviewAt: null }, { nextReviewAt: { lte: new Date() } }];
       where.status = "ACTIVE";
     }
 

--- a/src/app/api/wrong-notes/route.ts
+++ b/src/app/api/wrong-notes/route.ts
@@ -21,6 +21,7 @@ export async function GET(request: NextRequest) {
     const { searchParams } = request.nextUrl;
     const status = searchParams.get("status") || "ACTIVE";
     const topicId = searchParams.get("topicId");
+    const due = searchParams.get("due");
 
     const validStatuses = ["ACTIVE", "RESOLVED", "ALL"];
     if (!validStatuses.includes(status)) {
@@ -35,6 +36,11 @@ export async function GET(request: NextRequest) {
 
     if (topicId) {
       where.question = { topicId };
+    }
+
+    if (due === "true") {
+      where.nextReviewAt = { lte: new Date() };
+      where.status = "ACTIVE";
     }
 
     const wrongNotes = await prisma.wrongNote.findMany({
@@ -58,6 +64,8 @@ export async function GET(request: NextRequest) {
       consecutiveCorrect: note.consecutiveCorrect,
       createdAt: note.createdAt,
       resolvedAt: note.resolvedAt,
+      leitnerBox: note.leitnerBox,
+      nextReviewAt: note.nextReviewAt,
       question: {
         id: note.question.id,
         topicId: note.question.topicId,

--- a/src/app/api/wrong-notes/summary/route.ts
+++ b/src/app/api/wrong-notes/summary/route.ts
@@ -23,6 +23,22 @@ export async function GET() {
       prisma.wrongNote.count({ where: { userId, status: "RESOLVED" } }),
     ]);
 
+    const [dueCount, boxCounts] = await Promise.all([
+      prisma.wrongNote.count({
+        where: { userId, status: "ACTIVE", nextReviewAt: { lte: new Date() } },
+      }),
+      prisma.wrongNote.groupBy({
+        by: ["leitnerBox"],
+        where: { userId, status: "ACTIVE" },
+        _count: true,
+      }),
+    ]);
+
+    const boxDistribution = Array.from({ length: 6 }, (_, i) => {
+      const found = boxCounts.find((b) => b.leitnerBox === i);
+      return found ? found._count : 0;
+    });
+
     const byTopicRaw = await prisma.wrongNote.findMany({
       where: { userId, status: "ACTIVE" },
       select: {
@@ -49,7 +65,7 @@ export async function GET() {
       .map(([topicId, data]) => ({ topicId, ...data }))
       .sort((a, b) => b.count - a.count);
 
-    return NextResponse.json({ activeCount, resolvedCount, byTopic });
+    return NextResponse.json({ activeCount, resolvedCount, dueCount, boxDistribution, byTopic });
   } catch (error) {
     console.error("Failed to get wrong notes summary:", error);
     return NextResponse.json({ error: "Failed to get wrong notes summary" }, { status: 500 });

--- a/src/app/api/wrong-notes/summary/route.ts
+++ b/src/app/api/wrong-notes/summary/route.ts
@@ -23,9 +23,10 @@ export async function GET() {
       prisma.wrongNote.count({ where: { userId, status: "RESOLVED" } }),
     ]);
 
+    const now = new Date();
     const [dueCount, boxCounts] = await Promise.all([
       prisma.wrongNote.count({
-        where: { userId, status: "ACTIVE", nextReviewAt: { lte: new Date() } },
+        where: { userId, status: "ACTIVE", OR: [{ nextReviewAt: null }, { nextReviewAt: { lte: now } }] },
       }),
       prisma.wrongNote.groupBy({
         by: ["leitnerBox"],

--- a/src/app/daily/loading.tsx
+++ b/src/app/daily/loading.tsx
@@ -1,0 +1,27 @@
+import { Skeleton, SkeletonText } from '@/components/skeleton/Skeleton';
+
+export default function DailyLoading() {
+  return (
+    <main className="container mx-auto px-4 py-8">
+      <div className="max-w-3xl mx-auto">
+        <div className="flex justify-between items-center mb-8">
+          <div className="flex items-center gap-3">
+            <Skeleton className="w-10 h-10 rounded-2xl" />
+            <Skeleton className="h-8 w-32" />
+          </div>
+          <Skeleton className="h-8 w-16" />
+        </div>
+        <Skeleton className="h-2.5 w-full rounded-full mb-6" />
+        <Skeleton className="h-8 w-28 rounded-full mb-4" />
+        <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-lg border border-gray-100 dark:border-gray-700">
+          <SkeletonText className="w-3/4 mb-4 h-6" />
+          <div className="space-y-3">
+            {[1, 2, 3, 4].map((i) => (
+              <Skeleton key={i} className="h-12 w-full rounded-xl" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,8 @@ import UserMenu from "@/components/UserMenu";
 import LanguageToggle from "@/components/LanguageToggle";
 import FeedbackButton from "@/components/FeedbackButton";
 import DarkModeToggle from "@/components/DarkModeToggle";
+import { ToastProvider } from "@/contexts/ToastContext";
+import ToastContainer from "@/components/Toast";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -36,6 +38,7 @@ export default function RootLayout({
       <body className={`${inter.className} antialiased`}>
         <LanguageProvider>
           <AuthProvider>
+            <ToastProvider>
             {/* 헤더 */}
             <header className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 sticky top-0 z-40 shadow-sm">
               <div className="container mx-auto px-4 py-4 flex justify-between items-center">
@@ -80,6 +83,8 @@ export default function RootLayout({
               </div>
             </footer>
             <FeedbackButton />
+            <ToastContainer />
+            </ToastProvider>
           </AuthProvider>
         </LanguageProvider>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,6 +34,12 @@ export default function RootLayout({
             __html: `(function(){try{var s=localStorage.getItem('darkMode');var dark=s==='true'||(s===null&&window.matchMedia('(prefers-color-scheme: dark)').matches);if(dark)document.documentElement.classList.add('dark');}catch(e){}})();`,
           }}
         />
+        <script
+          src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.4/kakao.min.js"
+          integrity="sha384-DKYJZ8NLiK8MN4/C5P2ezmFnkrysYjmMbgGHpJiPlXBl/PKmwOMSWN+x54oEXmG"
+          crossOrigin="anonymous"
+          async
+        />
       </head>
       <body className={`${inter.className} antialiased`}>
         <LanguageProvider>

--- a/src/app/leaderboard/loading.tsx
+++ b/src/app/leaderboard/loading.tsx
@@ -1,0 +1,29 @@
+import { Skeleton } from '@/components/skeleton/Skeleton';
+
+export default function LeaderboardLoading() {
+  return (
+    <main className="container mx-auto px-4 py-8 min-h-screen">
+      <div className="max-w-4xl mx-auto">
+        <div className="flex justify-between items-center mb-8">
+          <div className="flex items-center gap-3">
+            <Skeleton className="w-10 h-10 md:w-14 md:h-14 rounded-xl md:rounded-2xl" />
+            <Skeleton className="h-8 w-36" />
+          </div>
+          <Skeleton className="h-8 w-16" />
+        </div>
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl overflow-hidden border-2 border-orange-100 dark:border-gray-700">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div key={i} className="flex items-center gap-4 p-4 border-b border-gray-100 dark:border-gray-700">
+              <Skeleton className="w-8 h-8 rounded-lg" />
+              <Skeleton className="h-5 w-24" />
+              <div className="ml-auto flex gap-4">
+                <Skeleton className="h-5 w-12" />
+                <Skeleton className="h-5 w-16" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/quiz/[topicId]/loading.tsx
+++ b/src/app/quiz/[topicId]/loading.tsx
@@ -1,0 +1,27 @@
+import { Skeleton, SkeletonText } from '@/components/skeleton/Skeleton';
+
+export default function QuizLoading() {
+  return (
+    <main className="container mx-auto px-4 py-8">
+      <div className="max-w-3xl mx-auto">
+        <div className="flex gap-2 mb-6">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-8 w-16 rounded-full" />
+          ))}
+        </div>
+        <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-lg border border-gray-100 dark:border-gray-700">
+          <SkeletonText className="w-3/4 mb-4 h-6" />
+          <SkeletonText className="w-full mb-6" />
+          <div className="space-y-3">
+            {[1, 2, 3, 4].map((i) => (
+              <Skeleton key={i} className="h-12 w-full rounded-xl" />
+            ))}
+          </div>
+          <div className="flex justify-end mt-6">
+            <Skeleton className="h-10 w-24 rounded-lg" />
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/quiz/[topicId]/page.tsx
+++ b/src/app/quiz/[topicId]/page.tsx
@@ -166,6 +166,17 @@ function QuizPageContent({ params }: QuizPageProps) {
           }
         }
       } catch { /* 스트릭 조회 실패해도 무시 */ }
+
+      // Weekly challenge toast
+      try {
+        const challengeRes = await fetch('/api/weekly-challenge');
+        if (challengeRes.ok) {
+          const challengeData = await challengeRes.json();
+          if (challengeData.topicId === params.topicId) {
+            toast.info(t('weeklyChallenge.toastSubmitted'));
+          }
+        }
+      } catch { /* 무시 */ }
     }
     if (solvedCount > 0) {
       setIsCompleted(true);

--- a/src/app/quiz/[topicId]/page.tsx
+++ b/src/app/quiz/[topicId]/page.tsx
@@ -8,6 +8,7 @@ import { useLanguage } from '@/contexts/LanguageContext';
 import QuestionComponent from '@/components/QuestionComponent';
 import { useDifficultyFilter } from '@/hooks/useDifficultyFilter';
 import { useToast } from '@/contexts/ToastContext';
+import ShareButtons from '@/components/ShareButtons';
 
 const BATCH_SIZE = 10;
 const PREFETCH_THRESHOLD = 3;
@@ -31,6 +32,7 @@ function QuizPageContent({ params }: QuizPageProps) {
   const startTimeRef = useRef(Date.now());
   const queueSnapshotRef = useRef({ queueLen: 0, idx: 0 });
 
+  const [isCompleted, setIsCompleted] = useState(false);
   const [solvedCount, setSolvedCount] = useState(0);
   const [correctCount, setCorrectCount] = useState(0);
   const [showStatTooltip, setShowStatTooltip] = useState(false);
@@ -165,7 +167,11 @@ function QuizPageContent({ params }: QuizPageProps) {
         }
       } catch { /* 스트릭 조회 실패해도 무시 */ }
     }
-    router.push('/');
+    if (solvedCount > 0) {
+      setIsCompleted(true);
+    } else {
+      router.push('/');
+    }
   };
 
   const filterConfig: Record<string, { tKey: string; selected: string; unselected: string }> = {
@@ -208,6 +214,26 @@ function QuizPageContent({ params }: QuizPageProps) {
   );
 
   const currentQuestion = questionQueue[currentIndex] ?? null;
+
+  if (isCompleted) {
+    const accuracy = solvedCount > 0 ? Math.round((correctCount / solvedCount) * 100) : 0;
+    return (
+      <main className="min-h-screen flex items-center justify-center py-8">
+        <div className="text-center bg-white dark:bg-gray-800 p-8 rounded-2xl shadow-2xl max-w-md w-full mx-4 border-2 border-orange-100 dark:border-gray-700">
+          <h2 className="text-3xl font-bold mb-4 text-gray-900 dark:text-gray-100">{t('daily.complete')}</h2>
+          <div className="p-5 bg-gradient-to-br from-orange-50 to-amber-50 dark:from-orange-900/20 dark:to-amber-900/20 border border-orange-200 dark:border-orange-800/30 rounded-xl mb-4">
+            <p className="text-4xl font-bold text-orange-600">{correctCount} / {solvedCount}</p>
+          </div>
+          <div className="mb-4">
+            <ShareButtons type="topic" score={accuracy} correct={correctCount} total={solvedCount} />
+          </div>
+          <button onClick={() => router.push('/')} className="w-full px-4 py-3 bg-gray-200 text-gray-700 rounded-xl hover:bg-gray-300 transition-colors font-semibold dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600">
+            {t('common.homeShort')}
+          </button>
+        </div>
+      </main>
+    );
+  }
 
   if (loading && !currentQuestion) {
     return (

--- a/src/app/quiz/[topicId]/page.tsx
+++ b/src/app/quiz/[topicId]/page.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useLanguage } from '@/contexts/LanguageContext';
 import QuestionComponent from '@/components/QuestionComponent';
 import { useDifficultyFilter } from '@/hooks/useDifficultyFilter';
+import { useToast } from '@/contexts/ToastContext';
 
 const BATCH_SIZE = 10;
 const PREFETCH_THRESHOLD = 3;
@@ -21,6 +22,7 @@ function QuizPageContent({ params }: QuizPageProps) {
   const router = useRouter();
   const { user } = useAuth();
   const { t } = useLanguage();
+  const toast = useToast();
   const [questionQueue, setQuestionQueue] = useState<QuestionData[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -146,6 +148,22 @@ function QuizPageContent({ params }: QuizPageProps) {
       } catch {
         // 저장 실패해도 홈으로 이동
       }
+
+      // Streak toast
+      try {
+        const streakRes = await fetch('/api/stats');
+        if (streakRes.ok) {
+          const streakData = await streakRes.json();
+          const { currentStreak, longestStreak } = streakData.streak;
+          if (currentStreak === 1) {
+            toast.info(t('streak.toastRestart'));
+          } else if (currentStreak === longestStreak && currentStreak > 1) {
+            toast.success(t('streak.toastNewRecord', { count: currentStreak }));
+          } else if (currentStreak > 1) {
+            toast.success(t('streak.toastContinue', { count: currentStreak }));
+          }
+        }
+      } catch { /* 스트릭 조회 실패해도 무시 */ }
     }
     router.push('/');
   };

--- a/src/app/share/result/page.tsx
+++ b/src/app/share/result/page.tsx
@@ -1,0 +1,37 @@
+import { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+
+interface ShareResultPageProps {
+  searchParams: {
+    type?: string;
+    score?: string;
+    correct?: string;
+    total?: string;
+    streak?: string;
+    date?: string;
+  };
+}
+
+export function generateMetadata({ searchParams }: ShareResultPageProps): Metadata {
+  const { type = 'daily', score = '0', correct = '0', total = '0', streak } = searchParams;
+  const typeLabel: Record<string, string> = { daily: '일일 퀴즈', topic: '주제별 퀴즈', review: '복습 퀴즈' };
+
+  const ogParams = new URLSearchParams({ type, score, correct, total });
+  if (streak) ogParams.set('streak', streak);
+
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://cs-quiz-ten.vercel.app';
+
+  return {
+    title: `CS Quiz ${typeLabel[type] || '퀴즈'} ${score}점!`,
+    description: `${correct}/${total} 정답 — 나도 풀어보기!`,
+    openGraph: {
+      title: `CS Quiz ${typeLabel[type] || '퀴즈'} ${score}점!`,
+      description: `${correct}/${total} 정답 — 나도 풀어보기!`,
+      images: [`${baseUrl}/api/og/quiz-result?${ogParams.toString()}`],
+    },
+  };
+}
+
+export default function ShareResultPage() {
+  redirect('/');
+}

--- a/src/app/stats/loading.tsx
+++ b/src/app/stats/loading.tsx
@@ -1,0 +1,26 @@
+import { Skeleton, SkeletonCard } from '@/components/skeleton/Skeleton';
+
+export default function StatsLoading() {
+  return (
+    <main className="container mx-auto px-4 py-8 min-h-screen">
+      <div className="max-w-4xl mx-auto">
+        <div className="flex justify-between items-center mb-8">
+          <div className="flex items-center gap-3">
+            <Skeleton className="w-10 h-10 md:w-14 md:h-14 rounded-xl md:rounded-2xl" />
+            <Skeleton className="h-8 w-28" />
+          </div>
+          <Skeleton className="h-8 w-16" />
+        </div>
+        <div className="grid grid-cols-3 gap-4 mb-8">
+          <SkeletonCard />
+          <SkeletonCard />
+          <SkeletonCard />
+        </div>
+        <div className="bg-white dark:bg-gray-800 rounded-xl p-4 md:p-6 shadow-md border border-gray-100 dark:border-gray-700 mb-8">
+          <Skeleton className="h-6 w-32 mb-4" />
+          <Skeleton className="h-64 md:h-80 w-full rounded" />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -34,6 +34,10 @@ interface StatsData {
   topicStats: TopicStat[];
   dailyTrend: DailyTrend[];
   weakAreas: TopicStat[];
+  streak: {
+    currentStreak: number;
+    longestStreak: number;
+  };
 }
 
 function formatTime(seconds: number, t: (key: string, params?: Record<string, string | number>) => string): string {
@@ -186,6 +190,35 @@ export default function StatsPage() {
             <p className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-gray-100">{formatTime(data.summary.totalTimeSeconds, t)}</p>
           </div>
         </div>
+
+        {/* Streak Card */}
+        {data.streak.currentStreak > 0 && (
+          <div className="bg-gradient-to-br from-orange-50 to-amber-50 dark:from-orange-900/20 dark:to-amber-900/20 rounded-xl p-4 md:p-6 shadow-md border border-orange-100 dark:border-orange-800/30 mb-8">
+            <div className="flex items-center gap-3 mb-3">
+              <span className="text-2xl">🔥</span>
+              <h2 className="text-lg md:text-xl font-bold text-gray-900 dark:text-gray-100">{t('streak.title')}</h2>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <p className="text-sm text-gray-500 dark:text-gray-400">{t('streak.current')}</p>
+                <p className="text-3xl font-bold text-orange-600">{t('streak.days', { count: data.streak.currentStreak })}</p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-500 dark:text-gray-400">{t('streak.longest')}</p>
+                <p className="text-3xl font-bold text-gray-700 dark:text-gray-300">{t('streak.days', { count: data.streak.longestStreak })}</p>
+              </div>
+            </div>
+            {data.streak.currentStreak >= 100 && (
+              <span className="mt-3 inline-block px-3 py-1 bg-orange-500 text-white text-sm font-bold rounded-full">{t('streak.milestone100')}</span>
+            )}
+            {data.streak.currentStreak >= 30 && data.streak.currentStreak < 100 && (
+              <span className="mt-3 inline-block px-3 py-1 bg-orange-500 text-white text-sm font-bold rounded-full">{t('streak.milestone30')}</span>
+            )}
+            {data.streak.currentStreak >= 7 && data.streak.currentStreak < 30 && (
+              <span className="mt-3 inline-block px-3 py-1 bg-orange-400 text-white text-sm font-bold rounded-full">{t('streak.milestone7')}</span>
+            )}
+          </div>
+        )}
 
         {/* Topic Accuracy Bar Chart */}
         <div className="bg-white dark:bg-gray-800 rounded-xl p-4 md:p-6 shadow-md border border-gray-100 dark:border-gray-700 mb-8">

--- a/src/app/weekly-challenge/page.tsx
+++ b/src/app/weekly-challenge/page.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { useAuth } from '@/contexts/AuthContext';
+import { Skeleton } from '@/components/skeleton/Skeleton';
+
+interface ChallengeInfo {
+  topicId: string;
+  topic: { name_ko: string; name_en: string };
+  remainingDays: number;
+}
+
+interface LeaderboardEntry {
+  rank: number;
+  username: string;
+  bestAccuracy: number;
+  totalSolved: number;
+}
+
+export default function WeeklyChallengePage() {
+  const router = useRouter();
+  const { t, language } = useLanguage();
+  const { user } = useAuth();
+  const [challenge, setChallenge] = useState<ChallengeInfo | null>(null);
+  const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.all([
+      fetch('/api/weekly-challenge').then((r) => r.json()),
+      fetch('/api/weekly-challenge/leaderboard').then((r) => r.json()),
+    ])
+      .then(([challengeData, lbData]) => {
+        setChallenge(challengeData);
+        setLeaderboard(lbData.leaderboard || []);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <main className="container mx-auto px-4 py-8 min-h-screen">
+        <div className="max-w-4xl mx-auto">
+          <Skeleton className="h-10 w-40 mb-8" />
+          <Skeleton className="h-20 w-full rounded-2xl mb-6" />
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-14 w-full rounded-xl mb-3" />
+          ))}
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="container mx-auto px-4 py-8 min-h-screen">
+      <div className="max-w-4xl mx-auto">
+        <div className="flex justify-between items-center mb-8">
+          <h1 className="text-2xl md:text-4xl font-bold text-gray-900 dark:text-gray-100 flex items-center gap-3">
+            <span className="text-3xl">🏆</span>
+            {t('weeklyChallenge.title')}
+          </h1>
+          <button onClick={() => router.push('/')} className="px-4 py-2 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors font-medium">
+            {t('common.homeShort')}
+          </button>
+        </div>
+
+        {challenge && (
+          <div className="p-6 bg-gradient-to-r from-purple-500 to-indigo-600 text-white rounded-2xl shadow-lg mb-8">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-purple-200 text-sm font-medium mb-1">{t('weeklyChallenge.banner')}</p>
+                <p className="text-2xl font-bold">
+                  {language === 'en' ? challenge.topic.name_en : challenge.topic.name_ko}
+                </p>
+              </div>
+              <div className="text-right">
+                <p className="text-purple-200 text-sm">{t('weeklyChallenge.remaining', { count: challenge.remainingDays })}</p>
+                <button
+                  onClick={() => router.push(`/quiz/${challenge.topicId}`)}
+                  className="mt-2 px-4 py-2 bg-white text-purple-600 rounded-lg font-semibold hover:bg-purple-50 transition-colors"
+                >
+                  {t('weeklyChallenge.goSolve')}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {leaderboard.length === 0 ? (
+          <div className="text-center py-12 bg-gray-50 dark:bg-gray-800/50 rounded-xl">
+            <p className="text-xl text-gray-600 dark:text-gray-400">{t('weeklyChallenge.noParticipants')}</p>
+            <p className="text-gray-500 dark:text-gray-500 mt-2">{t('weeklyChallenge.beFirst')}</p>
+          </div>
+        ) : (
+          <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl overflow-hidden border border-gray-200 dark:border-gray-700">
+            <div className="grid grid-cols-[60px_1fr_80px_80px] gap-2 px-4 py-3 bg-gradient-to-r from-purple-500 to-indigo-600 text-white font-bold text-sm">
+              <span>{t('weeklyChallenge.rank')}</span>
+              <span>{t('weeklyChallenge.user')}</span>
+              <span className="text-center">{t('weeklyChallenge.accuracy')}</span>
+              <span className="text-center">{t('weeklyChallenge.solved')}</span>
+            </div>
+            {leaderboard.map((entry) => {
+              const isCurrent = user && user.username === entry.username;
+              return (
+                <div
+                  key={entry.rank}
+                  className={`grid grid-cols-[60px_1fr_80px_80px] gap-2 px-4 py-3 border-b border-gray-100 dark:border-gray-700 ${isCurrent ? 'bg-purple-50 dark:bg-purple-900/20' : ''}`}
+                >
+                  <span className="font-bold text-gray-700 dark:text-gray-300">#{entry.rank}</span>
+                  <span className={`font-medium ${isCurrent ? 'text-purple-700 dark:text-purple-400 font-bold' : 'text-gray-900 dark:text-gray-200'}`}>
+                    {entry.username}
+                    {isCurrent && <span className="ml-2 px-1.5 py-0.5 bg-purple-500 text-white text-xs rounded-full">{t('common.me')}</span>}
+                  </span>
+                  <span className="text-center font-semibold text-gray-800 dark:text-gray-200">{entry.bestAccuracy}%</span>
+                  <span className="text-center text-gray-600 dark:text-gray-400">{entry.totalSolved}</span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/wrong-notes/loading.tsx
+++ b/src/app/wrong-notes/loading.tsx
@@ -1,0 +1,36 @@
+import { Skeleton, SkeletonCard } from '@/components/skeleton/Skeleton';
+
+export default function WrongNotesLoading() {
+  return (
+    <main className="container mx-auto px-4 py-8 min-h-screen">
+      <div className="max-w-4xl mx-auto">
+        <div className="flex justify-between items-center mb-8">
+          <div className="flex items-center gap-3">
+            <Skeleton className="w-10 h-10 md:w-14 md:h-14 rounded-xl md:rounded-2xl" />
+            <Skeleton className="h-8 w-28" />
+          </div>
+          <Skeleton className="h-8 w-16" />
+        </div>
+        <div className="grid grid-cols-2 gap-4 mb-8">
+          <SkeletonCard />
+          <SkeletonCard />
+        </div>
+        <div className="flex gap-2 mb-4">
+          <Skeleton className="h-9 w-20 rounded-full" />
+          <Skeleton className="h-9 w-20 rounded-full" />
+        </div>
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border border-gray-100 dark:border-gray-700">
+              <div className="flex gap-2 mb-2">
+                <Skeleton className="h-5 w-12 rounded-full" />
+                <Skeleton className="h-5 w-20" />
+              </div>
+              <Skeleton className="h-5 w-3/4" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/wrong-notes/page.tsx
+++ b/src/app/wrong-notes/page.tsx
@@ -12,6 +12,8 @@ interface WrongNoteItem {
   status: 'ACTIVE' | 'RESOLVED';
   wrongCount: number;
   consecutiveCorrect: number;
+  leitnerBox: number;
+  nextReviewAt: string | null;
   createdAt: string;
   resolvedAt: string | null;
   question: QuestionData & {
@@ -29,10 +31,12 @@ interface TopicCount {
 interface Summary {
   activeCount: number;
   resolvedCount: number;
+  dueCount: number;
+  boxDistribution: number[];
   byTopic: TopicCount[];
 }
 
-const GRADUATE_THRESHOLD = 3;
+const LEITNER_MAX_BOX = 5;
 
 export default function WrongNotesPage() {
   const router = useRouter();
@@ -139,6 +143,16 @@ export default function WrongNotesPage() {
             </div>
           </div>
         )}
+        {summary && summary.dueCount > 0 && (
+          <div className="mb-6 px-4 py-3 bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800/30 rounded-xl flex items-center justify-between">
+            <span className="text-orange-800 dark:text-orange-300 font-medium text-sm">
+              {t('wrongNotes.dueToday', { count: summary.dueCount })}
+            </span>
+            <span className="px-2 py-0.5 bg-orange-500 text-white text-xs font-bold rounded-full">
+              {summary.dueCount}
+            </span>
+          </div>
+        )}
 
         {/* Empty State */}
         {notes.length === 0 && (
@@ -243,11 +257,11 @@ export default function WrongNotesPage() {
                         </p>
                         {note.status === 'ACTIVE' && (
                           <div className="flex items-center gap-1 mt-1 justify-end">
-                            {Array.from({ length: GRADUATE_THRESHOLD }).map((_, i) => (
+                            {Array.from({ length: LEITNER_MAX_BOX }).map((_, i) => (
                               <div
                                 key={i}
                                 className={`w-2.5 h-2.5 rounded-full ${
-                                  i < note.consecutiveCorrect
+                                  i < note.leitnerBox
                                     ? 'bg-green-500'
                                     : 'bg-gray-200 dark:bg-gray-600'
                                 }`}

--- a/src/components/DailyQuizContent.tsx
+++ b/src/components/DailyQuizContent.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { TopicId, QuestionData } from '@/types/quizTypes';
 import { useToast } from '@/contexts/ToastContext';
+import ShareButtons from '@/components/ShareButtons';
 
 export interface DailyQuestion {
   id: string;
@@ -295,6 +296,15 @@ export default function DailyQuizContent({ questions, dailySetId }: DailyQuizCon
                   <p className="text-sm text-red-700">{t(scoreSubmitError) !== scoreSubmitError ? t(scoreSubmitError) : scoreSubmitError}</p>
                 </div>
               )}
+            </div>
+
+            <div className="mb-4">
+              <ShareButtons
+                type="daily"
+                score={score ?? Math.round((correctAnswers / questions.length) * 100)}
+                correct={correctAnswers}
+                total={questions.length}
+              />
             </div>
 
             {/* 버튼 */}

--- a/src/components/DailyQuizContent.tsx
+++ b/src/components/DailyQuizContent.tsx
@@ -7,6 +7,7 @@ import LoginModal from '@/components/LoginModal';
 import { useAuth } from '@/contexts/AuthContext';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { TopicId, QuestionData } from '@/types/quizTypes';
+import { useToast } from '@/contexts/ToastContext';
 
 export interface DailyQuestion {
   id: string;
@@ -37,6 +38,7 @@ export default function DailyQuizContent({ questions, dailySetId }: DailyQuizCon
   const router = useRouter();
   const { user } = useAuth();
   const { t, language } = useLanguage();
+  const toast = useToast();
   const [currentIndex, setCurrentIndex] = useState(0);
   const [correctAnswers, setCorrectAnswers] = useState(0);
   const [startTime] = useState(Date.now());
@@ -117,6 +119,22 @@ export default function DailyQuizContent({ questions, dailySetId }: DailyQuizCon
         setScore(result.score);
         setRank(result.rank);
         setPendingScoreSubmit(false);
+
+        // Streak toast
+        try {
+          const streakRes = await fetch('/api/stats');
+          if (streakRes.ok) {
+            const streakData = await streakRes.json();
+            const { currentStreak, longestStreak } = streakData.streak;
+            if (currentStreak === 1) {
+              toast.info(t('streak.toastRestart'));
+            } else if (currentStreak === longestStreak && currentStreak > 1) {
+              toast.success(t('streak.toastNewRecord', { count: currentStreak }));
+            } else if (currentStreak > 1) {
+              toast.success(t('streak.toastContinue', { count: currentStreak }));
+            }
+          }
+        } catch { /* ignore */ }
       } else if (res.status === 401) {
         const errorData = await res.json();
         const errorMsg = errorData.error || 'daily.loginRequired';
@@ -136,7 +154,7 @@ export default function DailyQuizContent({ questions, dailySetId }: DailyQuizCon
     } finally {
       setIsSubmittingScore(false);
     }
-  }, [startTime, dailySetId, correctAnswers, questions.length]);
+  }, [startTime, dailySetId, correctAnswers, questions.length, t, toast]);
 
   useEffect(() => {
     if (user && pendingScoreSubmit && isCompleted) {

--- a/src/components/DailyQuizContent.tsx
+++ b/src/components/DailyQuizContent.tsx
@@ -90,7 +90,7 @@ export default function DailyQuizContent({ questions, dailySetId }: DailyQuizCon
     setIsSubmittingScore(true);
 
     try {
-      fetch('/api/quiz-session', {
+      await fetch('/api/quiz-session', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/src/components/HomeContent.tsx
+++ b/src/components/HomeContent.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Topic } from '@/types/quizTypes';
 import { useAuth } from '@/contexts/AuthContext';
@@ -15,6 +16,19 @@ interface HomeContentProps {
 export default function HomeContent({ topics, dailySetId }: HomeContentProps) {
   const { user, isLoading: authLoading } = useAuth();
   const { t, language } = useLanguage();
+
+  const [challenge, setChallenge] = useState<{
+    topicId: string;
+    topic: { name_ko: string; name_en: string };
+    remainingDays: number;
+  } | null>(null);
+
+  useEffect(() => {
+    fetch('/api/weekly-challenge')
+      .then((r) => r.ok ? r.json() : null)
+      .then(setChallenge)
+      .catch(() => {});
+  }, []);
 
   return (
     <main className="container mx-auto px-4 py-8 min-h-screen flex flex-col items-center justify-center">
@@ -44,6 +58,29 @@ export default function HomeContent({ topics, dailySetId }: HomeContentProps) {
       </header>
 
       <div className="w-full max-w-4xl space-y-3">
+        {/* 주간 챌린지 배너 */}
+        {challenge && (
+          <Link
+            href={`/quiz/${challenge.topicId}`}
+            className="block p-4 bg-gradient-to-r from-purple-500 to-indigo-600 text-white rounded-2xl shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 transition-all group"
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 bg-white/20 backdrop-blur-sm rounded-xl flex items-center justify-center">
+                  <span className="text-xl">🏆</span>
+                </div>
+                <div>
+                  <p className="text-xs text-purple-200 font-medium">{t('weeklyChallenge.banner')}</p>
+                  <p className="text-lg font-bold">{language === 'en' ? challenge.topic.name_en : challenge.topic.name_ko}</p>
+                </div>
+              </div>
+              <div className="text-right">
+                <span className="text-sm text-purple-200">{t('weeklyChallenge.remaining', { count: challenge.remainingDays })}</span>
+              </div>
+            </div>
+          </Link>
+        )}
+
         {/* 오늘의 퀴즈 - 큰 버튼 */}
         <Link
           href={`/daily`}

--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useToast } from '@/contexts/ToastContext';
+import { useLanguage } from '@/contexts/LanguageContext';
+
+declare global {
+  interface Window {
+    Kakao?: {
+      isInitialized: () => boolean;
+      init: (key: string) => void;
+      Share: {
+        sendDefault: (params: Record<string, unknown>) => void;
+      };
+    };
+  }
+}
+
+interface ShareButtonsProps {
+  type: 'daily' | 'topic' | 'review';
+  score: number;
+  correct: number;
+  total: number;
+  streak?: number;
+}
+
+export default function ShareButtons({ type, score, correct, total, streak }: ShareButtonsProps) {
+  const toast = useToast();
+  const { t } = useLanguage();
+
+  const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
+  const params = new URLSearchParams({
+    type,
+    score: String(score),
+    correct: String(correct),
+    total: String(total),
+  });
+  if (streak && streak > 0) params.set('streak', String(streak));
+  const shareUrl = `${baseUrl}/share/result?${params.toString()}`;
+
+  const typeLabel: Record<string, string> = { daily: '일일 퀴즈', topic: '주제별 퀴즈', review: '복습 퀴즈' };
+  const shareTitle = `CS Quiz ${typeLabel[type]} ${score}점! (${correct}/${total})`;
+
+  const handleKakao = () => {
+    if (!window.Kakao) {
+      toast.error(t('share.kakaoNotLoaded'));
+      return;
+    }
+    if (!window.Kakao.isInitialized()) {
+      window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_JS_KEY || '');
+    }
+    window.Kakao.Share.sendDefault({
+      objectType: 'feed',
+      content: {
+        title: shareTitle,
+        description: '나도 CS 퀴즈 풀어보기!',
+        imageUrl: `${baseUrl}/api/og/quiz-result?${params.toString()}`,
+        link: { mobileWebUrl: shareUrl, webUrl: shareUrl },
+      },
+      buttons: [
+        { title: '나도 풀어보기', link: { mobileWebUrl: baseUrl, webUrl: baseUrl } },
+      ],
+    });
+  };
+
+  const handleTwitter = () => {
+    const text = encodeURIComponent(shareTitle);
+    const url = encodeURIComponent(shareUrl);
+    window.open(`https://x.com/intent/tweet?text=${text}&url=${url}`, '_blank');
+  };
+
+  const handleCopyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      toast.success(t('share.linkCopied'));
+    } catch {
+      toast.error(t('share.copyFailed'));
+    }
+  };
+
+  const btnBase = 'flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg font-medium text-sm transition-all';
+
+  return (
+    <div className="flex gap-2">
+      <button onClick={handleKakao} className={`${btnBase} bg-[#FEE500] text-[#191919] hover:bg-[#FDD835]`}>
+        카카오톡
+      </button>
+      <button onClick={handleTwitter} className={`${btnBase} bg-black text-white hover:bg-gray-800`}>
+        X
+      </button>
+      <button onClick={handleCopyLink} className={`${btnBase} bg-gray-200 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600`}>
+        {t('share.copyLink')}
+      </button>
+    </div>
+  );
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useToasts, ToastType } from '@/contexts/ToastContext';
+import { createPortal } from 'react-dom';
+import { useEffect, useState } from 'react';
+
+const iconMap: Record<ToastType, string> = {
+  success: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z',
+  error: 'M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z',
+  info: 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+};
+
+const colorMap: Record<ToastType, string> = {
+  success: 'bg-green-600 dark:bg-green-700',
+  error: 'bg-red-600 dark:bg-red-700',
+  info: 'bg-gray-700 dark:bg-gray-600',
+};
+
+export default function ToastContainer() {
+  const toasts = useToasts();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => { setMounted(true); }, []);
+
+  if (!mounted || toasts.length === 0) return null;
+
+  return createPortal(
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          className={`${colorMap[t.type]} text-white px-4 py-3 rounded-lg shadow-lg flex items-center gap-2 min-w-[200px] max-w-[360px] animate-in slide-in-from-right duration-200`}
+        >
+          <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={iconMap[t.type]} />
+          </svg>
+          <span className="text-sm font-medium">{t.message}</span>
+        </div>
+      ))}
+    </div>,
+    document.body
+  );
+}

--- a/src/components/skeleton/Skeleton.tsx
+++ b/src/components/skeleton/Skeleton.tsx
@@ -1,0 +1,24 @@
+interface SkeletonProps {
+  className?: string;
+}
+
+export function Skeleton({ className = '' }: SkeletonProps) {
+  return (
+    <div
+      className={`animate-pulse bg-gray-200 dark:bg-gray-700 rounded ${className}`}
+    />
+  );
+}
+
+export function SkeletonText({ className = '' }: SkeletonProps) {
+  return <Skeleton className={`h-4 ${className}`} />;
+}
+
+export function SkeletonCard({ className = '' }: SkeletonProps) {
+  return (
+    <div className={`bg-white dark:bg-gray-800 rounded-xl p-4 md:p-6 shadow-md border border-gray-100 dark:border-gray-700 ${className}`}>
+      <SkeletonText className="w-1/3 mb-3" />
+      <Skeleton className="h-8 w-1/2" />
+    </div>
+  );
+}

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { createContext, useCallback, useContext, useState, ReactNode } from 'react';
+
+export type ToastType = 'success' | 'error' | 'info';
+
+interface ToastItem {
+  id: number;
+  message: string;
+  type: ToastType;
+}
+
+interface ToastContextValue {
+  toasts: ToastItem[];
+  toast: {
+    success: (message: string) => void;
+    error: (message: string) => void;
+    info: (message: string) => void;
+  };
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+let nextId = 0;
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const addToast = useCallback((message: string, type: ToastType) => {
+    const id = nextId++;
+    setToasts((prev) => [...prev, { id, message, type }]);
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 3000);
+  }, []);
+
+  const toast = {
+    success: (message: string) => addToast(message, 'success'),
+    error: (message: string) => addToast(message, 'error'),
+    info: (message: string) => addToast(message, 'info'),
+  };
+
+  return (
+    <ToastContext.Provider value={{ toasts, toast }}>
+      {children}
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used within ToastProvider');
+  return ctx.toast;
+}
+
+export function useToasts() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToasts must be used within ToastProvider');
+  return ctx.toasts;
+}

--- a/src/lib/leitner.ts
+++ b/src/lib/leitner.ts
@@ -1,0 +1,19 @@
+// Box intervals in days: Box 0=immediate, 1=1day, 2=3days, 3=7days, 4=14days, 5=30days
+const INTERVALS_DAYS = [0, 1, 3, 7, 14, 30];
+export const MAX_BOX = 5;
+
+export function getNextReviewDate(box: number, now: Date = new Date()): Date {
+  const days = INTERVALS_DAYS[Math.min(box, MAX_BOX)] ?? 0;
+  const next = new Date(now);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+export function onCorrect(currentBox: number): { newBox: number; graduated: boolean } {
+  const newBox = Math.min(currentBox + 1, MAX_BOX + 1);
+  return { newBox, graduated: newBox > MAX_BOX };
+}
+
+export function onWrong(): { newBox: number } {
+  return { newBox: 0 };
+}

--- a/src/lib/streak.ts
+++ b/src/lib/streak.ts
@@ -1,0 +1,60 @@
+import { toKST } from './timezone';
+
+interface StreakResult {
+  currentStreak: number;
+  longestStreak: number;
+}
+
+export function calculateStreak(completedAts: Date[]): StreakResult {
+  if (completedAts.length === 0) return { currentStreak: 0, longestStreak: 0 };
+
+  // KST 기준 날짜 추출 → 중복 제거 → 내림차순 정렬
+  const dateSet = new Set<string>();
+  for (const d of completedAts) {
+    dateSet.add(toKST(d).toISOString().slice(0, 10));
+  }
+  const dates = Array.from(dateSet).sort().reverse(); // 최신 날짜 먼저
+
+  // 오늘 KST 날짜
+  const now = new Date();
+  const todayKST = toKST(now).toISOString().slice(0, 10);
+  const yesterdayDate = new Date(now);
+  yesterdayDate.setDate(yesterdayDate.getDate() - 1);
+  const yesterdayKST = toKST(yesterdayDate).toISOString().slice(0, 10);
+
+  // currentStreak: 오늘 또는 어제부터 연속
+  let currentStreak = 0;
+  const startDate = dates[0] === todayKST || dates[0] === yesterdayKST ? dates[0] : null;
+
+  if (startDate) {
+    let expected = startDate;
+    for (const date of dates) {
+      if (date === expected) {
+        currentStreak++;
+        const prev = new Date(expected + 'T00:00:00Z');
+        prev.setDate(prev.getDate() - 1);
+        expected = prev.toISOString().slice(0, 10);
+      } else if (date < expected) {
+        break;
+      }
+    }
+  }
+
+  // longestStreak: 전체 기간 중 최장 연속
+  let longestStreak = 1;
+  let streak = 1;
+  const sortedAsc = [...dates].reverse(); // 오름차순
+
+  for (let i = 1; i < sortedAsc.length; i++) {
+    const prev = new Date(sortedAsc[i - 1] + 'T00:00:00Z');
+    prev.setDate(prev.getDate() + 1);
+    if (prev.toISOString().slice(0, 10) === sortedAsc[i]) {
+      streak++;
+      longestStreak = Math.max(longestStreak, streak);
+    } else {
+      streak = 1;
+    }
+  }
+
+  return { currentStreak, longestStreak };
+}

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -184,6 +184,18 @@ const en = {
     reviewResultWrong: '{count} wrong',
     dueToday: '{count} questions due for review today',
   },
+  streak: {
+    title: 'Daily Streak',
+    current: 'Current',
+    longest: 'Longest',
+    days: '{count} days',
+    milestone7: '1 Week',
+    milestone30: '1 Month',
+    milestone100: '100 Days',
+    toastContinue: '{count}-day streak! Keep it up!',
+    toastNewRecord: 'New record! {count}-day streak!',
+    toastRestart: 'Back at it! Day 1',
+  },
 } as const;
 
 export default en;

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -182,6 +182,7 @@ const en = {
     reviewComplete: 'Review Complete!',
     reviewResultCorrect: '{count} correct',
     reviewResultWrong: '{count} wrong',
+    dueToday: '{count} questions due for review today',
   },
 } as const;
 

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -202,6 +202,20 @@ const en = {
     toastNewRecord: 'New record! {count}-day streak!',
     toastRestart: 'Back at it! Day 1',
   },
+  weeklyChallenge: {
+    title: 'Weekly Challenge',
+    banner: "This Week's Challenge",
+    remaining: '{count} days left',
+    leaderboard: 'Challenge Leaderboard',
+    rank: 'Rank',
+    user: 'User',
+    accuracy: 'Accuracy',
+    solved: 'Solved',
+    noParticipants: 'No participants yet',
+    beFirst: 'Be the first to participate!',
+    goSolve: 'Start Solving',
+    toastSubmitted: 'Weekly challenge score recorded!',
+  },
 } as const;
 
 export default en;

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -184,6 +184,12 @@ const en = {
     reviewResultWrong: '{count} wrong',
     dueToday: '{count} questions due for review today',
   },
+  share: {
+    linkCopied: 'Link copied!',
+    copyFailed: 'Failed to copy',
+    copyLink: 'Copy Link',
+    kakaoNotLoaded: 'Failed to load Kakao SDK',
+  },
   streak: {
     title: 'Daily Streak',
     current: 'Current',

--- a/src/lib/translations/ko.ts
+++ b/src/lib/translations/ko.ts
@@ -184,6 +184,18 @@ const ko = {
     reviewResultWrong: '{count}개 틀림',
     dueToday: '오늘 복습할 문제 {count}개',
   },
+  streak: {
+    title: '연속 출석',
+    current: '현재 연속',
+    longest: '최장 기록',
+    days: '{count}일',
+    milestone7: '1주 연속',
+    milestone30: '1달 연속',
+    milestone100: '100일 돌파',
+    toastContinue: '연속 {count}일째 퀴즈 풀이 중!',
+    toastNewRecord: '새 기록! 연속 {count}일 달성!',
+    toastRestart: '다시 시작! 연속 1일째',
+  },
 } as const;
 
 export default ko;

--- a/src/lib/translations/ko.ts
+++ b/src/lib/translations/ko.ts
@@ -202,6 +202,20 @@ const ko = {
     toastNewRecord: '새 기록! 연속 {count}일 달성!',
     toastRestart: '다시 시작! 연속 1일째',
   },
+  weeklyChallenge: {
+    title: '주간 챌린지',
+    banner: '이번 주 챌린지',
+    remaining: '{count}일 남음',
+    leaderboard: '챌린지 리더보드',
+    rank: '순위',
+    user: '유저',
+    accuracy: '정답률',
+    solved: '풀이 수',
+    noParticipants: '아직 참여자가 없습니다',
+    beFirst: '첫 번째 참여자가 되어보세요!',
+    goSolve: '풀러 가기',
+    toastSubmitted: '주간 챌린지 점수 반영!',
+  },
 } as const;
 
 export default ko;

--- a/src/lib/translations/ko.ts
+++ b/src/lib/translations/ko.ts
@@ -184,6 +184,12 @@ const ko = {
     reviewResultWrong: '{count}개 틀림',
     dueToday: '오늘 복습할 문제 {count}개',
   },
+  share: {
+    linkCopied: '링크가 복사되었습니다',
+    copyFailed: '복사에 실패했습니다',
+    copyLink: '링크 복사',
+    kakaoNotLoaded: '카카오 SDK를 불러오지 못했습니다',
+  },
   streak: {
     title: '연속 출석',
     current: '현재 연속',

--- a/src/lib/translations/ko.ts
+++ b/src/lib/translations/ko.ts
@@ -182,6 +182,7 @@ const ko = {
     reviewComplete: '복습 완료!',
     reviewResultCorrect: '{count}개 맞힘',
     reviewResultWrong: '{count}개 틀림',
+    dueToday: '오늘 복습할 문제 {count}개',
   },
 } as const;
 

--- a/src/lib/weekly-challenge.ts
+++ b/src/lib/weekly-challenge.ts
@@ -17,8 +17,9 @@ function getWeekStart(date: Date = new Date()): Date {
   const kst = new Date(date.getTime() + kstOffset);
   const day = kst.getUTCDay();
   const diff = day === 0 ? -6 : 1 - day;
-  const monday = new Date(Date.UTC(kst.getUTCFullYear(), kst.getUTCMonth(), kst.getUTCDate() + diff));
-  return monday;
+  // KST Monday 00:00:00 = UTC Sunday 15:00:00 (subtract KST offset)
+  const mondayKST = new Date(Date.UTC(kst.getUTCFullYear(), kst.getUTCMonth(), kst.getUTCDate() + diff));
+  return new Date(mondayKST.getTime() - kstOffset);
 }
 
 function getWeekNumber(date: Date): number {
@@ -40,10 +41,22 @@ export async function getCurrentChallenge() {
     const weekNum = getWeekNumber(new Date());
     const topicId = TOPIC_ORDER[((weekNum % TOPIC_ORDER.length) + TOPIC_ORDER.length) % TOPIC_ORDER.length];
 
-    challenge = await prisma.weeklyChallenge.create({
-      data: { weekStart, topicId },
-      include: { topic: { select: { id: true, name_ko: true, name_en: true } } },
-    });
+    try {
+      challenge = await prisma.weeklyChallenge.create({
+        data: { weekStart, topicId },
+        include: { topic: { select: { id: true, name_ko: true, name_en: true } } },
+      });
+    } catch (e: unknown) {
+      if (e && typeof e === 'object' && 'code' in e && e.code === 'P2002') {
+        challenge = await prisma.weeklyChallenge.findUnique({
+          where: { weekStart },
+          include: { topic: { select: { id: true, name_ko: true, name_en: true } } },
+        });
+        if (!challenge) throw e;
+      } else {
+        throw e;
+      }
+    }
   }
 
   const weekEnd = new Date(weekStart);

--- a/src/lib/weekly-challenge.ts
+++ b/src/lib/weekly-challenge.ts
@@ -1,0 +1,57 @@
+import prisma from './prisma';
+
+const TOPIC_ORDER = [
+  'algorithm',
+  'dataStructure',
+  'operatingSystem',
+  'computerNetworking',
+  'database',
+  'computerSecurity',
+  'computerArchitecture',
+  'softwareEngineering',
+  'springBoot',
+];
+
+function getWeekStart(date: Date = new Date()): Date {
+  const kstOffset = 9 * 60 * 60 * 1000;
+  const kst = new Date(date.getTime() + kstOffset);
+  const day = kst.getUTCDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  const monday = new Date(Date.UTC(kst.getUTCFullYear(), kst.getUTCMonth(), kst.getUTCDate() + diff));
+  return monday;
+}
+
+function getWeekNumber(date: Date): number {
+  const start = new Date(Date.UTC(2026, 0, 5)); // 2026-01-05 Monday baseline
+  const weekStart = getWeekStart(date);
+  const diff = weekStart.getTime() - start.getTime();
+  return Math.floor(diff / (7 * 24 * 60 * 60 * 1000));
+}
+
+export async function getCurrentChallenge() {
+  const weekStart = getWeekStart();
+
+  let challenge = await prisma.weeklyChallenge.findUnique({
+    where: { weekStart },
+    include: { topic: { select: { id: true, name_ko: true, name_en: true } } },
+  });
+
+  if (!challenge) {
+    const weekNum = getWeekNumber(new Date());
+    const topicId = TOPIC_ORDER[((weekNum % TOPIC_ORDER.length) + TOPIC_ORDER.length) % TOPIC_ORDER.length];
+
+    challenge = await prisma.weeklyChallenge.create({
+      data: { weekStart, topicId },
+      include: { topic: { select: { id: true, name_ko: true, name_en: true } } },
+    });
+  }
+
+  const weekEnd = new Date(weekStart);
+  weekEnd.setDate(weekEnd.getDate() + 7);
+  const remainingMs = weekEnd.getTime() - Date.now();
+  const remainingDays = Math.max(0, Math.ceil(remainingMs / (24 * 60 * 60 * 1000)));
+
+  return { challenge, weekStart, weekEnd, remainingDays };
+}
+
+export { getWeekStart };


### PR DESCRIPTION
## 요약
P1~P2 오픈 이슈 6개(#38, #39, #40, #41, #42, #48)를 기반→학습→소셜 순서로 구현.
각 단계가 다음 단계의 인프라가 되도록 설계하여 어디서 끊어도 완성도 있는 상태를 유지.

## 변경 내용

### 기반 인프라
- **#39 스켈레톤 로딩 UI** — `Skeleton` 빌딩 블록 + 5개 페이지(`quiz`, `daily`, `leaderboard`, `wrong-notes`, `stats`) `loading.tsx` 적용
- **#38 Toast 알림 시스템** — `ToastContext` + `ToastContainer` (success/error/info, 3초 자동 닫힘, 다크모드 대응)

### 학습 강화
- **#48 Leitner 망각 곡선** — `WrongNote`에 `leitnerBox`/`nextReviewAt`/`lastReviewedAt` 추가, 박스별 간격(즉시→1→3→7→14→30일), 기존 3회 연속 정답 졸업을 박스 5 졸업으로 대체, 복습 예정 뱃지
- **#41 스트릭 시스템** — KST 기준 연속 출석 계산, `/stats` 카드(불꽃+마일스톤 뱃지), 퀴즈 완료 Toast 알림

### 소셜 & 바이럴
- **#40 공유 카드** — `next/og` OG 이미지 생성 API, 카카오톡(JS SDK)+X(트위터)+링크 복사 공유 버튼, 토픽 퀴즈에 결과 화면 추가
- **#42 주간 챌린지** — `WeeklyChallenge` 모델(lazy creation), 9개 토픽 라운드 로빈, 홈 배너, `/weekly-challenge` 리더보드 페이지

## 주의사항
- Leitner 마이그레이션(`add-leitner-fields`)과 WeeklyChallenge 마이그레이션(`add-weekly-challenge`)이 포함됨 — 프로덕션 DB에 이미 적용 완료
- 카카오 SDK 키는 `NEXT_PUBLIC_KAKAO_JS_KEY` 환경변수 필요 (Vercel에 설정 필요)
- `NEXT_PUBLIC_BASE_URL` 환경변수도 OG 이미지 URL 생성에 사용

## 테스트
- [x] `npm run check` (lint + type-check) 통과
- [x] `npm run build` 프로덕션 빌드 성공 (18개 라우트 정상)
- [ ] 브라우저 수동 확인: 스켈레톤, Toast, Leitner 도트, 스트릭 카드, 공유 버튼, 주간 챌린지 배너