### PR TITLE
fix: OG 엔드포인트 query param 검증 및 Kakao SDK env 체크 추가

### DIFF
--- a/src/app/api/og/quiz-result/route.tsx
+++ b/src/app/api/og/quiz-result/route.tsx
@@ -3,19 +3,29 @@ import { NextRequest } from 'next/server';
 
 export const runtime = 'edge';
 
+const VALID_TYPES = ['daily', 'topic', 'review'] as const;
+const TYPE_LABELS: Record<string, string> = {
+  daily: '오늘의 퀴즈',
+  topic: '주제별 퀴즈',
+  review: '복습 퀴즈',
+};
+
+function clampInt(value: string | null, fallback: number, min: number, max: number): number {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(min, Math.min(max, Math.round(n)));
+}
+
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
-  const type = searchParams.get('type') || 'daily';
-  const score = searchParams.get('score') || '0';
-  const correct = searchParams.get('correct') || '0';
-  const total = searchParams.get('total') || '0';
-  const streak = searchParams.get('streak');
 
-  const typeLabel: Record<string, string> = {
-    daily: '오늘의 퀴즈',
-    topic: '주제별 퀴즈',
-    review: '복습 퀴즈',
-  };
+  const rawType = searchParams.get('type') || 'daily';
+  const type = (VALID_TYPES as readonly string[]).includes(rawType) ? rawType : 'daily';
+  const score = clampInt(searchParams.get('score'), 0, 0, 100);
+  const correct = clampInt(searchParams.get('correct'), 0, 0, 200);
+  const total = clampInt(searchParams.get('total'), 0, 1, 200);
+  const streakRaw = searchParams.get('streak');
+  const streak = streakRaw ? clampInt(streakRaw, 0, 0, 9999) : null;
 
   return new ImageResponse(
     (
@@ -45,7 +55,7 @@ export async function GET(request: NextRequest) {
           <span style={{ fontSize: '36px', fontWeight: 'bold', color: 'white' }}>CS Quiz</span>
         </div>
         <div style={{ fontSize: '20px', color: '#a78bfa', marginBottom: '12px', fontWeight: 600 }}>
-          {typeLabel[type] || typeLabel.daily}
+          {TYPE_LABELS[type]}
         </div>
         <div style={{ fontSize: '96px', fontWeight: 'bold', color: '#fb923c', lineHeight: 1 }}>
           {score}점
@@ -53,7 +63,7 @@ export async function GET(request: NextRequest) {
         <div style={{ fontSize: '28px', color: '#94a3b8', marginTop: '12px' }}>
           {correct} / {total} 정답
         </div>
-        {streak && Number(streak) > 0 && (
+        {streak !== null && streak > 0 && (
           <div
             style={{
               marginTop: '24px',

--- a/src/app/api/og/quiz-result/route.tsx
+++ b/src/app/api/og/quiz-result/route.tsx
@@ -11,6 +11,7 @@ const TYPE_LABELS: Record<string, string> = {
 };
 
 function clampInt(value: string | null, fallback: number, min: number, max: number): number {
+  if (value == null || value.trim() === '') return fallback;
   const n = Number(value);
   if (!Number.isFinite(n)) return fallback;
   return Math.max(min, Math.min(max, Math.round(n)));
@@ -22,8 +23,8 @@ export async function GET(request: NextRequest) {
   const rawType = searchParams.get('type') || 'daily';
   const type = (VALID_TYPES as readonly string[]).includes(rawType) ? rawType : 'daily';
   const score = clampInt(searchParams.get('score'), 0, 0, 100);
-  const correct = clampInt(searchParams.get('correct'), 0, 0, 200);
   const total = clampInt(searchParams.get('total'), 0, 1, 200);
+  const correct = clampInt(searchParams.get('correct'), 0, 0, total);
   const streakRaw = searchParams.get('streak');
   const streak = streakRaw ? clampInt(streakRaw, 0, 0, 9999) : null;
 

--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -46,7 +46,12 @@ export default function ShareButtons({ type, score, correct, total, streak }: Sh
       return;
     }
     if (!window.Kakao.isInitialized()) {
-      window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_JS_KEY || '');
+      const kakaoKey = process.env.NEXT_PUBLIC_KAKAO_JS_KEY;
+      if (!kakaoKey) {
+        toast.error(t('share.kakaoNotLoaded'));
+        return;
+      }
+      window.Kakao.init(kakaoKey);
     }
     window.Kakao.Share.sendDefault({
       objectType: 'feed',


### PR DESCRIPTION
## 요약
- OG 이미지 엔드포인트에 입력 검증이 없어 비정상 query param이 그대로 렌더링되는 문제 수정
- Kakao SDK 초기화 시 환경변수 미설정이면 빈 문자열로 init하던 문제 수정

## 변경 내용
- `src/app/api/og/quiz-result/route.tsx`: type enum 화이트리스트 검증, score/correct/total/streak 정수 클램핑 (`clampInt` 헬퍼), NaN/Infinity 방어
- `src/components/ShareButtons.tsx`: `NEXT_PUBLIC_KAKAO_JS_KEY` 미설정 시 에러 토스트 표시 후 early return

## 테스트
- [x] `npm run check` (lint + type-check) 통과 확인
- [x] 수동: 비정상 query param (`?score=abc&type=invalid`) 시 fallback 값 적용됨